### PR TITLE
Improve severity level support.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -261,7 +261,7 @@ module Fluent
 
     # Translates other severity strings to one of the valid values above.
     SEVERITY_TRANSLATIONS = {
-      'ERR' => 'ERROR',
+      # log4j levels (both current and obsolete).
       'WARN' => 'WARNING',
       'FATAL' => 'CRITICAL',
       'TRACE' => 'DEBUG',
@@ -269,6 +269,7 @@ module Fluent
       'FINE' => 'DEBUG',
       'FINER' => 'DEBUG',
       'FINEST' => 'DEBUG',
+      # single-letter levels.  Note E->ERROR and D->DEBUG.
       'D' => 'DEBUG',
       'I' => 'INFO',
       'N' => 'NOTICE',
@@ -276,21 +277,22 @@ module Fluent
       'E' => 'ERROR',
       'C' => 'CRITICAL',
       'A' => 'ALERT',
+      # other misc. translations.
+      'ERR' => 'ERROR',
     }
 
     def parse_severity(severity_str)
       # The API is case insensitive, but uppercase to make things simpler.
-      severity = severity_str.upcase
+      severity = severity_str.upcase.strip
 
       # If the severity is already valid, just return it.
       if (VALID_SEVERITIES.include?(severity))
         return severity
       end
 
-      # If the severity is an integer or a string containing an integer,
-      # return it as an integer, truncated to the closest valid value
-      # (multiples of 100 between 0-800).
-      if ((severity.is_a? Integer) || /\A\d+\z/.match(severity))
+      # If the severity is an integer (string) return it as an integer,
+      # truncated to the closest valid value (multiples of 100 between 0-800).
+      if (/\A\d+\z/.match(severity))
         begin
           numeric_severity = (severity.to_i / 100) * 100
           if (numeric_severity < 0)

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -269,6 +269,13 @@ module Fluent
       'FINE' => 'DEBUG',
       'FINER' => 'DEBUG',
       'FINEST' => 'DEBUG',
+      'D' => 'DEBUG',
+      'I' => 'INFO',
+      'N' => 'NOTICE',
+      'W' => 'WARNING',
+      'E' => 'ERROR',
+      'C' => 'CRITICAL',
+      'A' => 'ALERT',
     }
 
     def parse_severity(severity_str)
@@ -301,27 +308,6 @@ module Fluent
       # Try to translate the severity.
       if (SEVERITY_TRANSLATIONS.has_key?(severity))
         return SEVERITY_TRANSLATIONS[severity]
-      end
-
-      # If the string is one character long, map it to a known severity if
-      # possible. Note that 'E' maps to 'ERROR' and 'D' to 'DEBUG'.
-      if severity.length == 1
-        case severity
-        when 'D'
-          return 'DEBUG'
-        when 'I'
-          return 'INFO'
-        when 'N'
-          return 'NOTICE'
-        when 'W'
-          return 'WARNING'
-        when 'E'
-          return 'ERROR'
-        when 'C'
-          return 'CRITICAL'
-        when 'A'
-          return 'ALERT'
-        end
       end
 
       # If all else fails, use 'DEFAULT'.

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -362,10 +362,16 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
     assert_equal(800, test_obj.parse_severity('900'))
     assert_equal(0, test_obj.parse_severity('1'))
+    assert_equal(100, test_obj.parse_severity('105'))
     assert_equal(400, test_obj.parse_severity('420'))
     assert_equal(700, test_obj.parse_severity('799'))
 
+    assert_equal(100, test_obj.parse_severity('105 '))
+    assert_equal(100, test_obj.parse_severity('     105'))
+    assert_equal(100, test_obj.parse_severity('     105    '))
+
     assert_equal('DEFAULT', test_obj.parse_severity('-100'))
+    assert_equal('DEFAULT', test_obj.parse_severity('105 100'))
 
     # synonyms for existing log levels
     assert_equal('ERROR', test_obj.parse_severity('ERR'))
@@ -389,6 +395,15 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
     assert_equal('DEFAULT', test_obj.parse_severity('x'))
     assert_equal('DEFAULT', test_obj.parse_severity('-'))
+
+    # leading/trailing whitespace should be stripped
+    assert_equal('ERROR', test_obj.parse_severity('  ERROR'))
+    assert_equal('ERROR', test_obj.parse_severity('ERROR  '))
+    assert_equal('ERROR', test_obj.parse_severity('   ERROR  '))
+    assert_equal('ERROR', test_obj.parse_severity("\t  ERROR  "))
+
+    # space in the middle should not be stripped.
+    assert_equal('DEFAULT', test_obj.parse_severity('ER ROR'))
 
     # anything else should translate to 'DEFAULT'
     assert_equal('DEFAULT', test_obj.parse_severity(''))


### PR DESCRIPTION
- Ensure we only send valid severity enum values (or 'DEFAULT' if unknown).
- Translate "known" (mostly log4j) values into valid values.
- Translate single-character severities into valid values.
- Constrain numeric severities to valid values (multiples of 100 from 0-800).