### PR TITLE
Support setting custom GCE metadata from config

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'google-api-client', '>= 0.8'
   gem.add_development_dependency "rake", '>= 10.3.2'
   gem.add_development_dependency "webmock", '>= 1.17.0'
+  gem.add_development_dependency "test-unit", "~> 3.0.2"
 end


### PR DESCRIPTION
This pull request is to support setting custom GCE metadata from config.

Why do I need this feature is I want to use fluent-plugin-google-cloud from any servers not only GCE instances.

Google Cloud Logging is very awesome feature, but current fluent-plugin-google-cloud can only work on GCE instance, because plugin get instance metadata (project_id, zone, vm_id) using local API.

I'm very happy that you merge this pull request if you can.

- [x] Add GCE metadata config param `project_id`, `zone` and `vm_id`
- [x] Add dev dependency `"test-unit", "~> 3.0.2"` to fix fail test with `"fluentd" >= "0.12"`
- [x] Add test