### PR TITLE
Add support for Application Default Credentials.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'fluentd', '>= 0.10'
   gem.add_runtime_dependency 'google-api-client', '>= 0.8'
+  gem.add_runtime_dependency 'googleauth', '~> 0.4'
   gem.add_development_dependency "rake", '>= 10.3.2'
   gem.add_development_dependency "webmock", '>= 1.17.0'
   gem.add_development_dependency "test-unit", "~> 3.0.2"

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -33,7 +33,7 @@ module Fluent
 
     # If set, this specifies the location of the credentials file, overriding
     # the value of the GOOGLE_APPLICATION_CREDENTIALS environment variable.
-    config_param :application_default_credentials_path, :default => nil
+    config_param :application_credentials_path, :default => nil
 
     # DEPRECATED: Parameters necessary to use the private_key auth_method.
     config_param :private_key_email, :string, :default => nil
@@ -349,9 +349,8 @@ module Fluent
         @client.authorization = jwt_asserter.to_authorization
         @client.authorization.expiry = 3600  # 3600s is the max allowed value
       else
-        if !@application_default_credentials_path.nil?
-          ENV['GOOGLE_APPLICATION_CREDENTIALS'] =
-            @application_default_credentials_path
+        if !@application_credentials_path.nil?
+          ENV['GOOGLE_APPLICATION_CREDENTIALS'] = @application_credentials_path
         end
         @client.authorization = Google::Auth.get_application_default(
             LOGGING_SCOPE)

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -31,10 +31,6 @@ module Fluent
     # value is ignored.
     config_param :auth_method, :string, :default => nil
 
-    # If set, this specifies the location of the credentials file, overriding
-    # the value of the GOOGLE_APPLICATION_CREDENTIALS environment variable.
-    config_param :application_credentials_path, :default => nil
-
     # DEPRECATED: Parameters necessary to use the private_key auth_method.
     config_param :private_key_email, :string, :default => nil
     config_param :private_key_path, :string, :default => nil
@@ -349,9 +345,6 @@ module Fluent
         @client.authorization = jwt_asserter.to_authorization
         @client.authorization.expiry = 3600  # 3600s is the max allowed value
       else
-        if !@application_credentials_path.nil?
-          ENV['GOOGLE_APPLICATION_CREDENTIALS'] = @application_credentials_path
-        end
         @client.authorization = Google::Auth.get_application_default(
             LOGGING_SCOPE)
       end

--- a/test/plugin/data/credentials.json
+++ b/test/plugin/data/credentials.json
@@ -1,0 +1,8 @@
+{
+  "private_key_id": "cbedb7568906086cab57859bbfc1748749cc46c4",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIICdwIBADANBgkqhkiG9w0BAQEcAASCAmEwggJdAgEAAoGBAKizy6B+aJ0Wua0e\njZ3pkHV0a2Ce1prJGhzGL5NpkbUjk6J11Kwp1yvPikTwALyy4PtUIZ+23D/unVRM\nHlKa2MkHIGjJg+mykX5Bd7eRJOxdJ0iu+eRWh7HiH+mdDntHwaz4xXihJBog71qS\n+9N+r2hy1hicybechchMiXHhmWPbAgMBAAECgYEAnSzeI4qCZxEcLtnPcXeBWpz7\nycpTAWUpycMvsjTiRxR9YRhM65YT3cJ//VhqJ2S1ThOcPCt/KqViuX4tpiKUo7qA\nH1AI9APbTo66wiGpgy+qG0wPJkKIQC8PpITNNcHqcbbAsIr3/XQduihsqxP2W2mT\na0nk5XJghs1Wa0xt28ECQQDgMqZjVDcDQyqM+bcBKJUUc/247KusjpdK70r6sx2o\nkZJGy/w9exlM5QrB6DLpw34/p5x4MoecZ7lS3yHdmaEhAkEAwKHsV4k5SXTUp4+J\nWK6GlQVvnwc+PQdX5gzt4/gWSY0Op5EQ+YD6cC7Lkz+GzXUzvmdp35c0ahS93D1/\nZLTZewJBAIjOc3cHMNadyr5BtulPEUE0ro+EY/GlBS8lu/QlDmkJg2AOI3qEvliM\nvza58S9yKny/U5yJAPVw2cZ3ABxQHeECQDyBX8PrBURuXvE2o5RoVTtvlqziAi3X\nJaPLwdkOLqnxlX3KkgNcoM0l1amtlYDpZcRVcSs0+9TqKOyJoH8YUwsCQA4cJmv3\n119xcijXPM2HZOB5cCxTHj59MRtQlLboNZ2witDCJ20eG9AC3ZcH7csS0H9dz8Jr\nXGEoQMPD2ck4T0U\u003d\n-----END PRIVATE KEY-----\n",
+  "client_email": "847859579879-q8ancssppuvtv8dac0i742pslde81jgl@developer.gserviceaccount.com",
+  "client_id": "847859579879-q8ancssppuvtv8dac0i742pslde81jgl.apps.googleusercontent.com",
+  "type": "service_account"
+}
+

--- a/test/plugin/data/invalid_credentials.json
+++ b/test/plugin/data/invalid_credentials.json
@@ -1,0 +1,8 @@
+{
+  "private_key_id": "cbedb7568906086cab57859bbfc1748749cc46c4",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nCeci n'est pas une cle\n-----END PRIVATE KEY-----\n",
+  "client_email": "847859579879-q8ancssppuvtv8dac0i742pslde81jgl@developer.gserviceaccount.com",
+  "client_id": "847859579879-q8ancssppuvtv8dac0i742pslde81jgl.apps.googleusercontent.com",
+  "type": "service_account"
+}
+

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -62,11 +62,11 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   ]
 
   JSON_CREDENTIALS_CONFIG = %[
-    application_default_credentials_path test/plugin/data/credentials.json
+    application_credentials_path test/plugin/data/credentials.json
   ]
 
   INVALID_JSON_CREDENTIALS_CONFIG = %[
-    application_default_credentials_path test/plugin/data/invalid_credentials.json
+    application_credentials_path test/plugin/data/invalid_credentials.json
   ]
 
   PRIVATE_KEY_CONFIG = %[

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -134,24 +134,32 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def test_configure_invalid_configs
+    exception_count = 0
     begin
       d = create_driver(INVALID_CONFIG_MISSING_PRIVATE_KEY_PATH)
-      assert false
     rescue Fluent::ConfigError => error
       assert error.message.include? 'private_key_path'
+      exception_count += 1
     end
+    assert_equal 1, exception_count
+
+    exception_count = 0
     begin
       d = create_driver(INVALID_CONFIG_MISSING_PRIVATE_KEY_EMAIL)
-      assert false
     rescue Fluent::ConfigError => error
       assert error.message.include? 'private_key_email'
+      exception_count += 1
     end
+    assert_equal 1, exception_count
+
+    exception_count = 0
     begin
       d = create_driver(INVALID_CONFIG_MISSING_METADATA_VM_ID)
-      assert false
     rescue Fluent::ConfigError => error
       assert error.message.include? 'fetch_gce_metadata'
+      exception_count += 1
     end
+    assert_equal 1, exception_count
   end
 
   def test_metadata_loading

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -20,20 +20,16 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
 
+    # Setup stubs used for authentication.
+    ENV.delete('GOOGLE_APPLICATION_CREDENTIALS')
+    setup_auth_stubs
+
     # Create stubs for all the GCE metadata lookups the agent needs to make.
     stub_metadata_request('project/project-id', PROJECT_ID)
     stub_metadata_request('instance/zone', FULLY_QUALIFIED_ZONE)
     stub_metadata_request('instance/id', VM_ID)
     stub_metadata_request('instance/attributes/',
                           "attribute1\nattribute2\nattribute3")
-
-    stub_request(:post, 'https://accounts.google.com/o/oauth2/token').
-      with(:body => hash_including({:grant_type => AUTH_GRANT_TYPE})).
-      to_return(:body => "{\"access_token\": \"#{FAKE_AUTH_TOKEN}\"}",
-                :status => 200,
-                :headers => {'Content-Length' => FAKE_AUTH_TOKEN,
-                             'Content-Type' => 'application/json' })
-
     @logs_sent = []
   end
 
@@ -62,7 +58,15 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   AUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
   FAKE_AUTH_TOKEN = 'abc123'
 
-  COMPUTE_ENGINE_SERVICE_ACCOUNT_CONFIG = %[
+  APPLICATION_DEFAULT_CONFIG = %[
+  ]
+
+  JSON_CREDENTIALS_CONFIG = %[
+    application_default_credentials_path test/plugin/data/credentials.json
+  ]
+
+  INVALID_JSON_CREDENTIALS_CONFIG = %[
+    application_default_credentials_path test/plugin/data/invalid_credentials.json
   ]
 
   PRIVATE_KEY_CONFIG = %[
@@ -78,18 +82,15 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     vm_id #{CUSTOM_VM_ID}
   ]
 
-  INVALID_CONFIG1 = %[
+  INVALID_CONFIG_MISSING_PRIVATE_KEY_PATH = %[
     auth_method private_key
     private_key_email nobody@example.com
   ]
-  INVALID_CONFIG2 = %[
+  INVALID_CONFIG_MISSING_PRIVATE_KEY_EMAIL = %[
     auth_method private_key
     private_key_path /fake/path/to/key
   ]
-  INVALID_CONFIG3 = %[
-    auth_method service_account
-  ]
-  INVALID_CONFIG4 = %[
+  INVALID_CONFIG_MISSING_METADATA_VM_ID = %[
     fetch_gce_metadata false
     project_id #{CUSTOM_PROJECT_ID}
     zone #{CUSTOM_ZONE}
@@ -118,17 +119,17 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     }
   }
 
-  def create_driver(conf=PRIVATE_KEY_CONFIG)
+  def create_driver(conf=APPLICATION_DEFAULT_CONFIG)
     Fluent::Test::BufferedOutputTestDriver.new(
         Fluent::GoogleCloudOutput).configure(conf)
   end
 
-  def test_configure_service_account
-    d = create_driver(COMPUTE_ENGINE_SERVICE_ACCOUNT_CONFIG)
-    assert_equal 'compute_engine_service_account', d.instance.auth_method
+  def test_configure_service_account_application_default
+    d = create_driver(APPLICATION_DEFAULT_CONFIG)
+    assert d.instance.auth_method.nil?
   end
 
-  def test_configure_service_account
+  def test_configure_service_account_private_key
     d = create_driver(PRIVATE_KEY_CONFIG)
     assert_equal 'private_key', d.instance.auth_method
   end
@@ -142,25 +143,19 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_configure_invalid_configs
     begin
-      d = create_driver(INVALID_CONFIG1)
+      d = create_driver(INVALID_CONFIG_MISSING_PRIVATE_KEY_PATH)
       assert false
     rescue Fluent::ConfigError => error
       assert error.message.include? 'private_key_path'
     end
     begin
-      d = create_driver(INVALID_CONFIG2)
+      d = create_driver(INVALID_CONFIG_MISSING_PRIVATE_KEY_EMAIL)
       assert false
     rescue Fluent::ConfigError => error
       assert error.message.include? 'private_key_email'
     end
     begin
-      d = create_driver(INVALID_CONFIG3)
-      assert false
-    rescue Fluent::ConfigError => error
-      assert error.message.include? 'auth_method'
-    end
-    begin
-      d = create_driver(INVALID_CONFIG4)
+      d = create_driver(INVALID_CONFIG_MISSING_METADATA_VM_ID)
       assert false
     rescue Fluent::ConfigError => error
       assert error.message.include? 'fetch_gce_metadata'
@@ -168,7 +163,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def test_metadata_loading
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     d.run
     assert_equal PROJECT_ID, d.instance.project_id
     assert_equal ZONE, d.instance.zone
@@ -178,7 +173,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_managed_vm_metadata_loading
     setup_managed_vm_metadata_stubs
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     d.run
     assert_equal PROJECT_ID, d.instance.project_id
     assert_equal ZONE, d.instance.zone
@@ -199,6 +194,36 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_one_log
     setup_logging_stubs
+    d = create_driver()
+    d.emit({'message' => log_entry(0)})
+    d.run
+    verify_log_entries(1, COMPUTE_PARAMS)
+  end
+
+  def test_one_log_with_json_credentials
+    setup_logging_stubs
+    d = create_driver(JSON_CREDENTIALS_CONFIG)
+    d.emit({'message' => log_entry(0)})
+    d.run
+    verify_log_entries(1, COMPUTE_PARAMS)
+  end
+
+  def test_one_log_with_invalid_json_credentials
+    setup_logging_stubs
+    d = create_driver(INVALID_JSON_CREDENTIALS_CONFIG)
+    d.emit({'message' => log_entry(0)})
+    exception_count = 0
+    begin
+      d.run
+    rescue RuntimeError => error
+      assert error.message.include? 'Unable to read the credential file'
+      exception_count += 1
+    end
+    assert_equal 1, exception_count
+  end
+
+  def test_one_log_private_key
+    setup_logging_stubs
     d = create_driver(PRIVATE_KEY_CONFIG)
     d.emit({'message' => log_entry(0)})
     d.run
@@ -207,7 +232,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_struct_payload_log
     setup_logging_stubs
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     d.emit({'msg' => log_entry(0), 'tag2' => 'test', 'data' => 5000})
     d.run
     verify_log_entries(1, COMPUTE_PARAMS, 'structPayload') do |entry|
@@ -220,7 +245,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_timestamps
     setup_logging_stubs
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     expected_ts = []
     emit_index = 0
     [Time.at(123456.789), Time.at(0), Time.now].each do |ts|
@@ -248,7 +273,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_severities
     setup_logging_stubs
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     expected_severity = []
     emit_index = 0
     # Array of pairs of [parsed_severity, expected_severity]
@@ -269,7 +294,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_multiple_logs
     setup_logging_stubs
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     # Only test a few values because otherwise the test can take minutes.
     [2, 3, 5, 11, 50].each do |n|
       # The test driver doesn't clear its buffer of entries after running, so
@@ -287,7 +312,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     # the exception.
     stub_request(:post, uri_for_log(COMPUTE_PARAMS)).to_return(
         :status => 400, :body => "Bad Request")
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     d.emit({'message' => log_entry(0)})
     d.run
     assert_requested(:post, uri_for_log(COMPUTE_PARAMS), :times => 1)
@@ -297,7 +322,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   def client_error_helper(message)
     stub_request(:post, uri_for_log(COMPUTE_PARAMS)).to_return(
         :status => 401, :body => message)
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     d.emit({'message' => log_entry(0)})
     exception_count = 0
     begin
@@ -335,7 +360,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     # gets propagated through the plugin.
     stub_request(:post, uri_for_log(COMPUTE_PARAMS)).to_return(
         :status => 500, :body => "Server Error")
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     d.emit({'message' => log_entry(0)})
     exception_count = 0
     begin
@@ -351,7 +376,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   def test_one_managed_vm_log
     setup_managed_vm_metadata_stubs
     setup_logging_stubs
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     d.emit({'message' => log_entry(0)})
     d.run
     verify_log_entries(1, VMENGINE_PARAMS)
@@ -360,7 +385,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   def test_multiple_managed_vm_logs
     setup_managed_vm_metadata_stubs
     setup_logging_stubs
-    d = create_driver(PRIVATE_KEY_CONFIG)
+    d = create_driver()
     [2, 3, 5, 11, 50].each do |n|
       # The test driver doesn't clear its buffer of entries after running, so
       # do it manually here.
@@ -461,6 +486,35 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     stub_request(:get, 'http://metadata/computeMetadata/v1/' + metadata_path).
       to_return(:body => response_body, :status => 200,
                 :headers => {'Content-Length' => response_body.length})
+  end
+
+  def setup_auth_stubs
+    # Used by 'googleauth' to test whether we're running on GCE.
+    # It only cares about the request succeeding with Metdata-Flavor: Google.
+    stub_request(:get, 'http://169.254.169.254').
+      to_return(:status => 200, :headers => {'Metadata-Flavor' => 'Google'})
+
+    # Used by 'googleauth' to fetch the default service account credentials.
+    stub_request(:get, 'http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token').
+      to_return(:body => "{\"access_token\": \"#{FAKE_AUTH_TOKEN}\"}",
+                :status => 200,
+                :headers => {'Content-Length' => FAKE_AUTH_TOKEN.length,
+                             'Content-Type' => 'application/json' })
+
+    # Used when loading credentials from a JSON file.
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token').
+      with(:body => hash_including({:grant_type => AUTH_GRANT_TYPE})).
+      to_return(:body => "{\"access_token\": \"#{FAKE_AUTH_TOKEN}\"}",
+                :status => 200,
+                :headers => {'Content-Length' => FAKE_AUTH_TOKEN.length,
+                             'Content-Type' => 'application/json' })
+    # Used for 'private_key' auth.
+    stub_request(:post, 'https://accounts.google.com/o/oauth2/token').
+      with(:body => hash_including({:grant_type => AUTH_GRANT_TYPE})).
+      to_return(:body => "{\"access_token\": \"#{FAKE_AUTH_TOKEN}\"}",
+                :status => 200,
+                :headers => {'Content-Length' => FAKE_AUTH_TOKEN.length,
+                             'Content-Type' => 'application/json' })
   end
 
   def setup_managed_vm_metadata_stubs

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -61,14 +61,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   APPLICATION_DEFAULT_CONFIG = %[
   ]
 
-  JSON_CREDENTIALS_CONFIG = %[
-    application_credentials_path test/plugin/data/credentials.json
-  ]
-
-  INVALID_JSON_CREDENTIALS_CONFIG = %[
-    application_credentials_path test/plugin/data/invalid_credentials.json
-  ]
-
   PRIVATE_KEY_CONFIG = %[
     auth_method private_key
     private_key_email 271661262351-ft99kc9kjro9rrihq3k2n3s2inbplu0q@developer.gserviceaccount.com
@@ -202,7 +194,8 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_one_log_with_json_credentials
     setup_logging_stubs
-    d = create_driver(JSON_CREDENTIALS_CONFIG)
+    ENV['GOOGLE_APPLICATION_CREDENTIALS'] = 'test/plugin/data/credentials.json'
+    d = create_driver()
     d.emit({'message' => log_entry(0)})
     d.run
     verify_log_entries(1, COMPUTE_PARAMS)
@@ -210,7 +203,8 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_one_log_with_invalid_json_credentials
     setup_logging_stubs
-    d = create_driver(INVALID_JSON_CREDENTIALS_CONFIG)
+    ENV['GOOGLE_APPLICATION_CREDENTIALS'] = 'test/plugin/data/invalid_credentials.json'
+    d = create_driver()
     d.emit({'message' => log_entry(0)})
     exception_count = 0
     begin


### PR DESCRIPTION
* Support Application Default Credentials and JSON keys.
* Application Default Credentials is now the default.
  Note that this still falls back to using the service account if no other
  credentials are found so there should be no change for existing users.
* auth_method is now deprecated; we emit a warning if it is configured.
  private_key is still supported for existing users.
* add a config option application_default_credentials_path, since setting
  environment variables for fluentd is inconvenient.
* The default path is $HOME/.config/gcloud/application_default_credentials.json
  ($HOME likely resolves to /root on GCE)
* Ensure the tests are actually exercising all auth methods (and using
  Application Default Credentials for most tests).
* Some misc cleanup in tests.