### PR TITLE
Fix a metadata exception on non-GCE platforms

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", '>= 10.3.2'
   gem.add_development_dependency "webmock", '>= 1.17.0'
   gem.add_development_dependency "test-unit", "~> 3.0.2"
+  gem.add_development_dependency "mocha", "~> 1.1"
 end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -114,7 +114,8 @@ module Fluent
       # If this is running on a Managed VM, grab the relevant App Engine
       # metadata as well.
       # TODO: Add config options for these to allow for running outside GCE?
-      attributes_string = fetch_metadata('instance/attributes/')
+      attributes_string = @fetch_gce_metadata ?
+          fetch_metadata('instance/attributes/') : ""
       attributes = attributes_string.split
       if (attributes.include?('gae_backend_name') &&
           attributes.include?('gae_backend_version'))

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -178,7 +178,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def test_gce_metadata_does_not_load_when_fetch_gce_metadata_is_false
-    setup_gce_metadata_stubs
     d = create_driver(CUSTOM_METADATA_CONFIG)
     d.run
     assert_equal CUSTOM_PROJECT_ID, d.instance.project_id

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -14,6 +14,7 @@
 
 require 'helper'
 require 'json'
+require 'mocha/test_unit'
 require 'webmock/test_unit'
 
 class GoogleCloudOutputTest < Test::Unit::TestCase
@@ -185,6 +186,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def test_gce_metadata_does_not_load_when_fetch_gce_metadata_is_false
+    Fluent::GoogleCloudOutput.any_instance.expects(:fetch_metadata).never
     d = create_driver(CUSTOM_METADATA_CONFIG)
     d.run
     assert_equal CUSTOM_PROJECT_ID, d.instance.project_id
@@ -238,6 +240,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def test_one_log_custom_metadata
+    Fluent::GoogleCloudOutput.any_instance.expects(:fetch_metadata).never
     ENV['GOOGLE_APPLICATION_CREDENTIALS'] = 'test/plugin/data/credentials.json'
     setup_logging_stubs
     d = create_driver(CUSTOM_METADATA_CONFIG)


### PR DESCRIPTION
- Fix a bug where we tried to fetch GCE metadata in one case even when
  fetch_gce_metadata was false.
- Factor the GCE fake stub setup out of the tests so we can control when they
  are installed
- Add a test that sends a log with custom metadata to make sure we're
  exercising this code path (I verfied the test fails without the change
  to the plugin so it would have caught this bug).