### PR TITLE
Add stub request for refresh auth token to fix failed test

### DIFF
--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -554,6 +554,14 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
                 :status => 200,
                 :headers => {'Content-Length' => FAKE_AUTH_TOKEN.length,
                              'Content-Type' => 'application/json' })
+
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token').
+      with(:body => hash_including({:grant_type => 'refresh_token'})).
+      to_return(:body => "{\"access_token\": \"#{FAKE_AUTH_TOKEN}\"}",
+                :status => 200,
+                :headers => {'Content-Length' => FAKE_AUTH_TOKEN.length,
+                             'Content-Type' => 'application/json' })
+
     # Used for 'private_key' auth.
     stub_request(:post, 'https://accounts.google.com/o/oauth2/token').
       with(:body => hash_including({:grant_type => AUTH_GRANT_TYPE})).


### PR DESCRIPTION
When I checked out current master branch and run `bundle exec rake test`, I got following error.

```
  WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: POST https://www.googleapis.com/oauth2/v3/token with body 'grant_type=refresh_token&refresh_token=1%2FBrB9HSuFjmdqNUdYqaisimWm0RC2Bbj8AnbWJ4eNw9w&client_id=32555940559.apps.googleusercontent.com&client_secret=ZmssLNjJy2998hD4CTg2ejr2' with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Cache-Control'=>'no-store', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Ruby'}

... (Getting same errors ....)

26 tests, 134 assertions, 0 failures, 14 errors, 0 pendings, 0 omissions, 0 notifications
46.1538% passed
```

I add stub request for `refresh_token`, it's fixed.
But I cannot be sure that this is a correct way to fix the problem.
Should we have to stub `refresh_token` request?