### PR TITLE
Rename fetch_gce_metadata to use_metadata_service

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -36,10 +36,10 @@ module Fluent
     config_param :private_key_path, :string, :default => nil
     config_param :private_key_passphrase, :string, :default => 'notasecret'
 
-    # If fetch_gce_metadata is set to true, we obtain the project_id, zone,
+    # If use_metadata_service is set to true, we obtain the project_id, zone,
     # and vm_id from the GCE metadata service.  Otherwise, those parameters
     # must be specified in the config file explicitly.
-    config_param :fetch_gce_metadata, :bool, :default => true
+    config_param :use_metadata_service, :bool, :default => true
     config_param :project_id, :string, :default => nil
     config_param :zone, :string, :default => nil
     config_param :vm_id, :string, :default => nil
@@ -86,10 +86,10 @@ module Fluent
         end
       end
 
-      unless @fetch_gce_metadata
+      unless @use_metadata_service
         unless @project_id && @zone && @vm_id
           raise Fluent::ConfigError,
-              ('Please specify "project_id", "zone" and "vm_id" if you set "fetch_gce_metadata" to false')
+              ('Please specify "project_id", "zone" and "vm_id" if you set "use_metadata_service" to false')
         end
       end
     end
@@ -101,7 +101,7 @@ module Fluent
 
       @successful_call = false
 
-      if @fetch_gce_metadata
+      if @use_metadata_service
         # Grab metadata about the Google Compute Engine instance that we're on.
         @project_id = fetch_metadata('project/project-id')
         fully_qualified_zone = fetch_metadata('instance/zone')
@@ -114,7 +114,7 @@ module Fluent
       # If this is running on a Managed VM, grab the relevant App Engine
       # metadata as well.
       # TODO: Add config options for these to allow for running outside GCE?
-      attributes_string = @fetch_gce_metadata ?
+      attributes_string = @use_metadata_service ?
           fetch_metadata('instance/attributes/') : ""
       attributes = attributes_string.split
       if (attributes.include?('gae_backend_name') &&

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -51,7 +51,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   ]
 
   CUSTOM_METADATA_CONFIG = %[
-    fetch_gce_metadata false
+    use_metadata_service false
     project_id #{CUSTOM_PROJECT_ID}
     zone #{CUSTOM_ZONE}
     vm_id #{CUSTOM_VM_ID}
@@ -66,7 +66,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     private_key_path /fake/path/to/key
   ]
   INVALID_CONFIG_MISSING_METADATA_VM_ID = %[
-    fetch_gce_metadata false
+    use_metadata_service false
     project_id #{CUSTOM_PROJECT_ID}
     zone #{CUSTOM_ZONE}
   ]
@@ -156,7 +156,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     begin
       d = create_driver(INVALID_CONFIG_MISSING_METADATA_VM_ID)
     rescue Fluent::ConfigError => error
-      assert error.message.include? 'fetch_gce_metadata'
+      assert error.message.include? 'use_metadata_service'
       exception_count += 1
     end
     assert_equal 1, exception_count
@@ -185,7 +185,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     assert_equal MANAGED_VM_BACKEND_VERSION, d.instance.gae_backend_version
   end
 
-  def test_gce_metadata_does_not_load_when_fetch_gce_metadata_is_false
+  def test_gce_metadata_does_not_load_when_use_metadata_service_is_false
     Fluent::GoogleCloudOutput.any_instance.expects(:fetch_metadata).never
     d = create_driver(CUSTOM_METADATA_CONFIG)
     d.run


### PR DESCRIPTION
Rename the config option fetch_gce_metadata to use_metadata_service
so it applies to non-GCE platforms.