### PR TITLE
Improve nanosecond timestamp support.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -167,7 +167,21 @@ module Fluent
           'entries' => [],
         }
         arr.each do |time, record|
-          if (record.has_key?('timeNanos'))
+          if (record.has_key?('timestamp') &&
+              record['timestamp'].has_key?('seconds') &&
+              record['timestamp'].has_key?('nanos'))
+            ts_secs = record['timestamp']['seconds']
+            ts_nanos = record['timestamp']['nanos']
+            record.delete('timestamp')
+          elsif (record.has_key?('timestampSeconds') &&
+                 record.has_key?('timestampNanos'))
+            ts_secs = record['timestampSeconds']
+            ts_nanos = record['timestampNanos']
+            record.delete('timestampSeconds')
+            record.delete('timestampNanos')
+          elsif (record.has_key?('timeNanos'))
+            # This is deprecated since the precision is insufficient.
+            # Use timestampSeconds/timestampNanos instead
             ts_secs = (record['timeNanos'] / 1000000000).to_i
             ts_nanos = record['timeNanos'] % 1000000000
             record.delete('timeNanos')

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -100,6 +100,7 @@ module Fluent
       init_api_client()
 
       @successful_call = false
+      @timenanos_warning = false
 
       if @use_metadata_service
         # Grab metadata about the Google Compute Engine instance that we're on.
@@ -185,6 +186,12 @@ module Fluent
             ts_secs = (record['timeNanos'] / 1000000000).to_i
             ts_nanos = record['timeNanos'] % 1000000000
             record.delete('timeNanos')
+            if (!@timenanos_warning)
+              # Warn the user this is deprecated, but only once to avoid spam.
+              @timenanos_warning = true
+              $log.warn ("timeNanos is deprecated - please use " +
+                         "timestampSeconds and timestampNanos instead.")
+            end
           else
             timestamp = Time.at(time)
             ts_secs = timestamp.tv_sec

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -270,7 +270,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     expected_ts = []
     emit_index = 0
     [Time.at(123456.789), Time.at(0), Time.now].each do |ts|
-      # Test both the "native" fluentd timestamp and timeNanos.
+      # Test the "native" fluentd timestamp as well as our nanosecond tags.
       d.emit({'message' => log_entry(emit_index)}, ts.to_f)
       # The native timestamp currently only supports second granularity
       # (fluentd issue #461), so strip nanoseconds from the expected value.
@@ -278,6 +278,14 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       emit_index += 1
       d.emit({'message' => log_entry(emit_index),
               'timeNanos' => ts.tv_sec * 1000000000 + ts.tv_nsec})
+      expected_ts.push(ts)
+      emit_index += 1
+      d.emit({'message' => log_entry(emit_index),
+              'timestamp' => {'seconds' => ts.tv_sec, 'nanos' => ts.tv_nsec}})
+      expected_ts.push(ts)
+      emit_index += 1
+      d.emit({'message' => log_entry(emit_index),
+              'timestampSeconds' => ts.tv_sec, 'timestampNanos' => ts.tv_nsec})
       expected_ts.push(ts)
       emit_index += 1
     end


### PR DESCRIPTION
- timeNanos is deprecated because the 53 bit mantissa used for doubles
  does not have sufficient precision to represent the current time in
  nanoseconds past the unix epoch (which currently requires 61 bits).
- instead, we now support formats with split seconds and nanoseconds:
  - timestampSeconds, timestampNanos
  - timestamp { seconds, nanos }
  
  In both cases, the "seconds" part represents seconds since the unix epoch,
  and the "nano" part is the nanosecond component only (0..999999999).

  Managed VMs is using the latter, but it can only be ingested via
  json/msgpack/etc, while the former is suitable for use in an in_tail regex.

This should be considered an interim solution until
https://github.com/fluent/fluentd/issues/461 is resolved.