### PR TITLE
Drop log entries which are not Hashes.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -168,6 +168,7 @@ module Fluent
           'entries' => [],
         }
         arr.each do |time, record|
+          next unless record.is_a? Hash
           if (record.has_key?('timestamp') &&
               record['timestamp'].has_key?('seconds') &&
               record['timestamp'].has_key?('nanos'))
@@ -224,6 +225,8 @@ module Fluent
           end
           write_log_entries_request['entries'].push(entry)
         end
+        # Don't send an empty request if we rejected all the entries.
+        next if write_log_entries_request['entries'].empty?
 
         # Add a prefix to VMEngines logs to prevent namespace collisions,
         # and also escape the log name.

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -338,6 +338,16 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     end
   end
 
+  def test_malformed_log
+    setup_gce_metadata_stubs
+    setup_logging_stubs
+    d = create_driver()
+    # if the entry is not a hash, the plugin should silently drop it.
+    d.emit("a string is not a valid message")
+    d.run
+    assert @logs_sent.empty?
+  end
+
   def test_client_error
     setup_gce_metadata_stubs
     # The API Client should not retry this and the plugin should consume


### PR DESCRIPTION
- fluentd requires 'record' to be a hash, but since it does not enforce that
  there are ways for non-hash records to slip through.  although this will
  be fixed upstream, it doesn't hurt to be defensive like some other plugins
  do.  without this change we will throw an exception.

  See https://github.com/fluent/fluentd/issues/591