### PR TITLE
Replace uses of 'metadata' with IP 169.254.169.254

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -288,7 +288,7 @@ module Fluent
     end
 
     def fetch_metadata(metadata_path)
-      open('http://metadata/computeMetadata/v1/' + metadata_path,
+      open('http://169.254.169.254/computeMetadata/v1/' + metadata_path,
            {'Metadata-Flavor' => 'Google'}) do |f|
         f.read
       end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -288,6 +288,7 @@ module Fluent
     end
 
     def fetch_metadata(metadata_path)
+      # Fetch GCE metadata - see https://cloud.google.com/compute/docs/metadata
       open('http://169.254.169.254/computeMetadata/v1/' + metadata_path,
            {'Metadata-Flavor' => 'Google'}) do |f|
         f.read

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -529,7 +529,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def stub_metadata_request(metadata_path, response_body)
-    stub_request(:get, 'http://metadata/computeMetadata/v1/' + metadata_path).
+    stub_request(:get, 'http://169.254.169.254/computeMetadata/v1/' + metadata_path).
       to_return(:body => response_body, :status => 200,
                 :headers => {'Content-Length' => response_body.length})
   end


### PR DESCRIPTION
The documentation doesn't give any guidance about whether to use the name
or IP address, but I've had customer reports (on Docker) of failing to
resolve the name, so using the IP address and eliminating the DNS
dependency (the name is *not* in /etc/hosts) seems preferable.

There's precedent for doing this in
https://github.com/google/google-auth-library-ruby