### PR TITLE
Allow overriding metadata service attributes.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -313,7 +313,7 @@ module Fluent
     def log_write_failure(request, error)
       dropped = request['entries'].length
       $log.warn "Dropping #{dropped} log message(s)",
-        :error_class=>error.class.to_s, :error=>error.to_s
+        :error_class => error.class.to_s, :error => error.to_s
     end
 
     # "enum" of Platform values
@@ -338,7 +338,7 @@ module Fluent
           end
         end
       rescue Exception => e
-        $log.debug "Failed to access metadata service: ", :error=>e
+        $log.debug "Failed to access metadata service: ", :error => e
       end
 
       $log.info 'Unable to determine platform'

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -36,10 +36,16 @@ module Fluent
     config_param :private_key_path, :string, :default => nil
     config_param :private_key_passphrase, :string, :default => 'notasecret'
 
-    # If use_metadata_service is set to true, we obtain the project_id, zone,
-    # and vm_id from the GCE metadata service.  Otherwise, those parameters
-    # must be specified in the config file explicitly.
+    # Specify project/instance metadata.
+    #
+    # project_id, zone, and vm_id are required to have valid values, which
+    # can be obtained from the metadata service or set explicitly.
+    # Otherwise, the plugin will fail to initialize.
+    #
+    # Whether to attempt to obtain metadata from the local metadata service.
+    # It is safe to specify 'true' even on platforms with no metadata service.
     config_param :use_metadata_service, :bool, :default => true
+    # These parameters override any values obtained from the metadata service.
     config_param :project_id, :string, :default => nil
     config_param :zone, :string, :default => nil
     config_param :vm_id, :string, :default => nil
@@ -86,37 +92,55 @@ module Fluent
         end
       end
 
-      unless @use_metadata_service
-        unless @project_id && @zone && @vm_id
-          raise Fluent::ConfigError,
-              ('Please specify "project_id", "zone" and "vm_id" if you set "use_metadata_service" to false')
+      if @use_metadata_service
+        if @project_id.nil?
+          begin
+            @project_id = fetch_metadata('project/project-id')
+          rescue
+            @project_id = nil
+          end
+        end
+        if @zone.nil?
+          begin
+            fully_qualified_zone = fetch_metadata('instance/zone')
+            @zone = fully_qualified_zone.rpartition('/')[2]
+          rescue
+            @zone = nil
+          end
+        end
+        if @vm_id.nil?
+          begin
+            @vm_id = fetch_metadata('instance/id')
+          rescue
+            vm_id = nil
+          end
         end
       end
-    end
 
-    def start
-      super
-
-      init_api_client()
-
-      @successful_call = false
-      @timenanos_warning = false
-
-      if @use_metadata_service
-        # Grab metadata about the Google Compute Engine instance that we're on.
-        @project_id = fetch_metadata('project/project-id')
-        fully_qualified_zone = fetch_metadata('instance/zone')
-        @zone = fully_qualified_zone.rpartition('/')[2]
-        @vm_id = fetch_metadata('instance/id')
+      # all metadata parameters must now be set
+      unless @project_id && @zone && @vm_id
+        missing = []
+        missing << "project_id" unless @project_id
+        missing << "zone" unless @zone
+        missing << "vm_id" unless @vm_id
+        raise Fluent::ConfigError,
+          ('Unable to obtain metadata parameters: ' + missing.join(' '))
       end
+
       # TODO: Send instance tags and/or hostname with the logs as well?
       @common_labels = {}
 
       # If this is running on a Managed VM, grab the relevant App Engine
       # metadata as well.
       # TODO: Add config options for these to allow for running outside GCE?
-      attributes_string = @use_metadata_service ?
-          fetch_metadata('instance/attributes/') : ""
+      attributes_string = ""
+      if (@use_metadata_service)
+        begin
+          attributes_string = fetch_metadata('instance/attributes/')
+        rescue
+          attributes_string = ""
+        end
+      end
       attributes = attributes_string.split
       if (attributes.include?('gae_backend_name') &&
           attributes.include?('gae_backend_version'))
@@ -142,6 +166,15 @@ module Fluent
         common_labels["#{COMPUTE_SERVICE}/resource_type"] = 'instance'
         common_labels["#{COMPUTE_SERVICE}/resource_id"] = @vm_id
       end
+    end
+
+    def start
+      super
+
+      init_api_client()
+
+      @successful_call = false
+      @timenanos_warning = false
     end
 
     def shutdown

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -251,6 +251,8 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def test_metadata_overrides_on_gce
+    # In this case we are overriding all configured parameters so we should
+    # see all "custom" values rather than the ones from the metadata server.
     setup_gce_metadata_stubs
     d = create_driver(CUSTOM_METADATA_CONFIG)
     d.run
@@ -261,6 +263,8 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def test_metadata_partial_overrides_on_gce
+    # Similar to above, but we are not overriding project_id in this config
+    # so we should see the metadata value for project_id and "custom" otherwise.
     setup_gce_metadata_stubs
     d = create_driver(CONFIG_MISSING_METADATA_PROJECT_ID)
     d.run

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -25,22 +25,27 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     @logs_sent = []
   end
 
+  # attributes used for the metadata service
   PROJECT_ID = 'test-project-id'
   ZONE = 'us-central1-b'
   FULLY_QUALIFIED_ZONE = 'projects/' + PROJECT_ID + '/zones/' + ZONE
   VM_ID = '9876543210'
 
+  # attributes used for custom (overridden) configs
   CUSTOM_PROJECT_ID = 'test-custom-project-id'
   CUSTOM_ZONE = 'us-custom-central1-b'
   CUSTOM_FULLY_QUALIFIED_ZONE = 'projects/' + PROJECT_ID + '/zones/' + ZONE
   CUSTOM_VM_ID = 'C9876543210'
 
+  # Managed VMs specific labels
   MANAGED_VM_BACKEND_NAME = 'default'
   MANAGED_VM_BACKEND_VERSION = 'guestbook2.0'
 
+  # Parameters used for authentication
   AUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
   FAKE_AUTH_TOKEN = 'abc123'
 
+  # Configuration files for various test scenarios
   APPLICATION_DEFAULT_CONFIG = %[
   ]
 
@@ -50,27 +55,40 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     private_key_path test/plugin/data/c31e573fd7f62ed495c9ca3821a5a85cb036dee1-privatekey.p12
   ]
 
-  CUSTOM_METADATA_CONFIG = %[
+  NO_METADATA_SERVICE_CONFIG = %[
     use_metadata_service false
+  ]
+
+  CUSTOM_METADATA_CONFIG = %[
     project_id #{CUSTOM_PROJECT_ID}
     zone #{CUSTOM_ZONE}
     vm_id #{CUSTOM_VM_ID}
   ]
 
-  INVALID_CONFIG_MISSING_PRIVATE_KEY_PATH = %[
+  CONFIG_MISSING_PRIVATE_KEY_PATH = %[
     auth_method private_key
     private_key_email nobody@example.com
   ]
-  INVALID_CONFIG_MISSING_PRIVATE_KEY_EMAIL = %[
+  CONFIG_MISSING_PRIVATE_KEY_EMAIL = %[
     auth_method private_key
     private_key_path /fake/path/to/key
   ]
-  INVALID_CONFIG_MISSING_METADATA_VM_ID = %[
-    use_metadata_service false
+  CONFIG_MISSING_METADATA_PROJECT_ID = %[
+    zone #{CUSTOM_ZONE}
+    vm_id #{CUSTOM_VM_ID}
+  ]
+  CONFIG_MISSING_METADATA_ZONE = %[
+    project_id #{CUSTOM_PROJECT_ID}
+    vm_id #{CUSTOM_VM_ID}
+  ]
+  CONFIG_MISSING_METADATA_VM_ID = %[
     project_id #{CUSTOM_PROJECT_ID}
     zone #{CUSTOM_ZONE}
   ]
+  CONFIG_MISSING_METADATA_ALL = %[
+  ]
 
+  # Service configurations for various services
   COMPUTE_SERVICE_NAME = 'compute.googleapis.com'
   APPENGINE_SERVICE_NAME = 'appengine.googleapis.com'
 
@@ -127,16 +145,17 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def test_configure_custom_metadata
+    setup_no_metadata_service_stubs
     d = create_driver(CUSTOM_METADATA_CONFIG)
     assert_equal CUSTOM_PROJECT_ID, d.instance.project_id
     assert_equal CUSTOM_ZONE, d.instance.zone
     assert_equal CUSTOM_VM_ID, d.instance.vm_id
   end
 
-  def test_configure_invalid_configs
+  def test_configure_invalid_private_key_configs
     exception_count = 0
     begin
-      d = create_driver(INVALID_CONFIG_MISSING_PRIVATE_KEY_PATH)
+      d = create_driver(CONFIG_MISSING_PRIVATE_KEY_PATH)
     rescue Fluent::ConfigError => error
       assert error.message.include? 'private_key_path'
       exception_count += 1
@@ -145,18 +164,54 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
     exception_count = 0
     begin
-      d = create_driver(INVALID_CONFIG_MISSING_PRIVATE_KEY_EMAIL)
+      d = create_driver(CONFIG_MISSING_PRIVATE_KEY_EMAIL)
     rescue Fluent::ConfigError => error
       assert error.message.include? 'private_key_email'
+      exception_count += 1
+    end
+    assert_equal 1, exception_count
+  end
+
+  def test_configure_invalid_metadata_configs_no_metadata_service
+    setup_no_metadata_service_stubs
+    exception_count = 0
+    begin
+      d = create_driver(CONFIG_MISSING_METADATA_PROJECT_ID)
+    rescue Fluent::ConfigError => error
+      assert error.message.include? 'Unable to obtain metadata parameters:'
+      assert error.message.include? 'project_id'
       exception_count += 1
     end
     assert_equal 1, exception_count
 
     exception_count = 0
     begin
-      d = create_driver(INVALID_CONFIG_MISSING_METADATA_VM_ID)
+      d = create_driver(CONFIG_MISSING_METADATA_ZONE)
     rescue Fluent::ConfigError => error
-      assert error.message.include? 'use_metadata_service'
+      assert error.message.include? 'Unable to obtain metadata parameters:'
+      assert error.message.include? 'zone'
+      exception_count += 1
+    end
+    assert_equal 1, exception_count
+
+    exception_count = 0
+    begin
+      d = create_driver(CONFIG_MISSING_METADATA_VM_ID)
+    rescue Fluent::ConfigError => error
+      assert error.message.include? 'Unable to obtain metadata parameters:'
+      assert error.message.include? 'vm_id'
+      exception_count += 1
+    end
+    assert_equal 1, exception_count
+
+    exception_count = 0
+    begin
+      d = create_driver(CONFIG_MISSING_METADATA_ALL)
+    rescue Fluent::ConfigError => error
+      assert error.message.include? 'Unable to obtain metadata parameters:'
+      assert error.message.include? 'project_id'
+      assert error.message.include? 'zone'
+      assert error.message.include? 'vm_id'
       exception_count += 1
     end
     assert_equal 1, exception_count
@@ -187,9 +242,29 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_gce_metadata_does_not_load_when_use_metadata_service_is_false
     Fluent::GoogleCloudOutput.any_instance.expects(:fetch_metadata).never
+    d = create_driver(NO_METADATA_SERVICE_CONFIG + CUSTOM_METADATA_CONFIG)
+    d.run
+    assert_equal CUSTOM_PROJECT_ID, d.instance.project_id
+    assert_equal CUSTOM_ZONE, d.instance.zone
+    assert_equal CUSTOM_VM_ID, d.instance.vm_id
+    assert_equal false, d.instance.running_on_managed_vm
+  end
+
+  def test_metadata_overrides_on_gce
+    setup_gce_metadata_stubs
     d = create_driver(CUSTOM_METADATA_CONFIG)
     d.run
     assert_equal CUSTOM_PROJECT_ID, d.instance.project_id
+    assert_equal CUSTOM_ZONE, d.instance.zone
+    assert_equal CUSTOM_VM_ID, d.instance.vm_id
+    assert_equal false, d.instance.running_on_managed_vm
+  end
+
+  def test_metadata_partial_overrides_on_gce
+    setup_gce_metadata_stubs
+    d = create_driver(CONFIG_MISSING_METADATA_PROJECT_ID)
+    d.run
+    assert_equal PROJECT_ID, d.instance.project_id
     assert_equal CUSTOM_ZONE, d.instance.zone
     assert_equal CUSTOM_VM_ID, d.instance.vm_id
     assert_equal false, d.instance.running_on_managed_vm
@@ -240,10 +315,12 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def test_one_log_custom_metadata
+    # don't set up any metadata stubs, so the test will fail if we try to
+    # fetch metadata (and explicitly check this as well).
     Fluent::GoogleCloudOutput.any_instance.expects(:fetch_metadata).never
     ENV['GOOGLE_APPLICATION_CREDENTIALS'] = 'test/plugin/data/credentials.json'
     setup_logging_stubs
-    d = create_driver(CUSTOM_METADATA_CONFIG)
+    d = create_driver(NO_METADATA_SERVICE_CONFIG + CUSTOM_METADATA_CONFIG)
     d.emit({'message' => log_entry(0)})
     d.run
     verify_log_entries(1, CUSTOM_PARAMS)
@@ -532,6 +609,12 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     stub_request(:get, 'http://169.254.169.254/computeMetadata/v1/' + metadata_path).
       to_return(:body => response_body, :status => 200,
                 :headers => {'Content-Length' => response_body.length})
+  end
+
+  def setup_no_metadata_service_stubs
+    # Simulate a machine with no metadata service present
+    stub_request(:any, /http:\/\/169.254.169.254\/.*/).
+      to_raise Errno::EHOSTUNREACH;
   end
 
   def setup_gce_metadata_stubs


### PR DESCRIPTION
- Previously, the plugin could either obtain metadata from the metadata
  service or from the config file, depending on the setting of
  use_metadata_service.
- Now, we allow the user to override metadata in the config file even
  if use_metadata_service is true (the default).  Configured data has
  precedence over data obtained from the service.
- Fetching from the metadata service now happens in config() rather
  than start().  This shouldn't have any practical impact.
- I restructured the tests a bit and added tests for various illegal
  configs and overriding data.