### PR TITLE
Ensure label values are strings.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,7 +7,7 @@
 
 # Offense count: 2
 Metrics/AbcSize:
-  Max: 80
+  Max: 81
 
 # Offense count: 2
 # Configuration parameters: CountComments.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -302,10 +302,10 @@ module Fluent
           unless label_map.nil?
             labels = {}
             @label_map.each do |field, label|
-              if record.key?(field)
-                labels[label] = record[field]
-                record.delete(field)
-              end
+              next unless record.key?(field)
+              # label values are required to be strings.
+              labels[label] = record[field].to_s
+              record.delete(field)
             end
             entry['metadata']['labels'] = labels unless labels.empty?
           end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -550,6 +550,22 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     verify_log_entries(1, params)
   end
 
+  def test_label_map_with_hash_field
+    setup_gce_metadata_stubs
+    setup_logging_stubs
+    config = %(label_map { "label_field": "sent_label" })
+    d = create_driver(config)
+    # I'm not sure this actually makes sense for a user to do, but make
+    # sure that it works if they try it.
+    d.emit('message' => log_entry(0),
+           'label_field' => { 'k1' => 10, 'k2' => 'val' })
+    d.run
+    # make a deep copy of COMPUTE_PARAMS and add the parsed label.
+    params = Marshal.load(Marshal.dump(COMPUTE_PARAMS))
+    params['labels']['sent_label'] = '{"k1"=>10, "k2"=>"val"}'
+    verify_log_entries(1, params)
+  end
+
   def test_label_map_with_multiple_fields
     setup_gce_metadata_stubs
     setup_logging_stubs


### PR DESCRIPTION
Label values are required to be strings, so when using label_map,
coerce the parsed value to be a string.

I confirmed the test I added failed before changing the plugin and
passes now.

Rubocop also made me make a couple changes (including replacing the
conditional with 'next unless ...')