### PR TITLE
Gemspec description update

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -2,9 +2,9 @@ Gem::Specification.new do |gem|
   gem.name          = 'fluent-plugin-google-cloud'
   gem.description   = <<-eos
    Fluentd output plugin for the Google Cloud Logging API, which will make
-   loge viewable in the Developer Console's log viewer and can optionally
+   logs viewable in the Developer Console's log viewer and can optionally
    store them in Google Cloud Storage and/or BigQuery.
-   This is an official Google Ruby gem.'
+   This is an official Google Ruby gem.
 eos
   gem.summary       =  'fluentd output plugin for the Google Cloud Logging API'
   gem.homepage      = \


### PR DESCRIPTION
Fixed a spelling error s/loge/logs/ and removed the trailing
single quote from the end of the string since it's unnecessary.