### PR TITLE
Add support for attaching container metadata based on the tag.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,7 +21,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 5
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 100
+  Max: 150
 
 # Offense count: 3
 Metrics/PerceivedComplexity:


### PR DESCRIPTION
This will be useful in the short term, because the kubernetes metadata
filter plugin isn't actually broadly usable until another kubernetes
feature (the daemon controller) gets in that will allow the metadata
plugin to authenticate to the kubernetes API.

This breaks rubocop due to the long write() function. It probably needs broader refactoring than what belongs in this commit, but I'm happy to fix it up here if you'd like.

@mr-salty @jimmidyson @brendandburns