### PR TITLE
Fix misordered expectation and value in assert statement.

### DIFF
--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -1049,7 +1049,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       assert value.is_a?(String), "Value #{value} for label #{key} " \
         'is not a string: ' + value.class.name
       assert expected_labels.key?(key), "Unexpected label #{key} => #{value}"
-      assert_equal value, expected_labels[key], 'Value mismatch - expected ' \
+      assert_equal expected_labels[key], value, 'Value mismatch - expected ' \
         "#{expected_labels[key]} in #{key} => #{value}"
     end
     assert_equal expected_labels.length, all_labels.length, 'Expected ' \


### PR DESCRIPTION
This makes the error message label the expectation and actual value
correctly rather than mixing them up.

Just a minor thing I bumped into while verifying #36.

@mr-salty 