### PR TITLE
Add support for Cloud Functions logs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,12 +7,12 @@
 
 # Offense count: 2
 Metrics/AbcSize:
-  Max: 100
+  Max: 120
 
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 1000
+  Max: 1200
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -246,7 +246,7 @@ module Fluent
             @kube_env = YAML.load(@raw_kube_env)
             common_labels["#{CONTAINER_SERVICE}/cluster_name"] =
               cluster_name_from_kube_env(@kube_env)
-            detect_cloudfunctions(attributes, common_labels)
+            detect_cloudfunctions(attributes)
           end
         end
         common_labels["#{COMPUTE_SERVICE}/resource_type"] = 'instance'
@@ -317,6 +317,7 @@ module Fluent
             # coming from a function.
             @service_name = CLOUDFUNCTIONS_SERVICE
             labels = write_log_entries_request['commonLabels']
+            labels["#{CLOUDFUNCTIONS_SERVICE}/region"] = @gcf_region
             labels["#{CLOUDFUNCTIONS_SERVICE}/function_name"] =
               match_data['function_name']
           else
@@ -526,12 +527,11 @@ module Fluent
       end
     end
 
-    def detect_cloudfunctions(attributes, common_labels)
+    def detect_cloudfunctions(attributes)
       return unless attributes.include?('gcf_region')
       # Cloud Functions detected
       @running_cloudfunctions = true
       @gcf_region = fetch_gce_metadata('instance/attributes/gcf_region')
-      common_labels["#{CLOUDFUNCTIONS_SERVICE}/region"] = @gcf_region
     end
 
     def cluster_name_from_kube_env(kube_env)

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -68,6 +68,15 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   CONTAINER_POD_NAME = 'redis-master-c0l82.foo.bar'
   CONTAINER_CONTAINER_NAME = 'redis'
 
+  # Cloud Functions specific labels
+  CLOUDFUNCTIONS_FUNCTION_NAME = 'function-1'
+  CLOUDFUNCTIONS_REGION = 'us-central1'
+  CLOUDFUNCTIONS_EXECUTION_ID = '123456789-0'
+  CLOUDFUNCTIONS_CLUSTER_NAME = 'gcf-cluster-1'
+  CLOUDFUNCTIONS_NAMESPACE_NAME = 'default'
+  CLOUDFUNCTIONS_POD_NAME = "#{CLOUDFUNCTIONS_FUNCTION_NAME}-c0l82"
+  CLOUDFUNCTIONS_CONTAINER_NAME = 'worker'
+
   # Parameters used for authentication
   AUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
   FAKE_AUTH_TOKEN = 'abc123'
@@ -135,6 +144,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   COMPUTE_SERVICE_NAME = 'compute.googleapis.com'
   APPENGINE_SERVICE_NAME = 'appengine.googleapis.com'
   CONTAINER_SERVICE_NAME = 'container.googleapis.com'
+  CLOUDFUNCTIONS_SERVICE_NAME = 'cloudfunctions.googleapis.com'
   EC2_SERVICE_NAME = 'ec2.amazonaws.com'
 
   COMPUTE_PARAMS = {
@@ -197,6 +207,34 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       "#{CONTAINER_SERVICE_NAME}/namespace_name" => CONTAINER_NAMESPACE_NAME,
       "#{CONTAINER_SERVICE_NAME}/pod_name" => CONTAINER_POD_NAME,
       "#{CONTAINER_SERVICE_NAME}/container_name" => CONTAINER_CONTAINER_NAME,
+      "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
+      "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
+      "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME
+    }
+  }
+
+  CLOUDFUNCTIONS_TAG = "kubernetes.#{CLOUDFUNCTIONS_POD_NAME}_" \
+                        "#{CLOUDFUNCTIONS_NAMESPACE_NAME}_" \
+                        "#{CLOUDFUNCTIONS_CONTAINER_NAME}"
+
+  CLOUDFUNCTIONS_PARAMS = {
+    'service_name' => CLOUDFUNCTIONS_SERVICE_NAME,
+    'log_name' => 'cloud-functions',
+    'project_id' => PROJECT_ID,
+    'zone' => ZONE,
+    'severity' => 'DEBUG',
+    'labels' => {
+      "#{CLOUDFUNCTIONS_SERVICE_NAME}/function_name" =>
+        CLOUDFUNCTIONS_FUNCTION_NAME,
+      "#{CLOUDFUNCTIONS_SERVICE_NAME}/region" => CLOUDFUNCTIONS_REGION,
+      'execution_id' => CLOUDFUNCTIONS_EXECUTION_ID,
+      "#{CONTAINER_SERVICE_NAME}/instance_id" => VM_ID,
+      "#{CONTAINER_SERVICE_NAME}/cluster_name" => CLOUDFUNCTIONS_CLUSTER_NAME,
+      "#{CONTAINER_SERVICE_NAME}/namespace_name" =>
+        CLOUDFUNCTIONS_NAMESPACE_NAME,
+      "#{CONTAINER_SERVICE_NAME}/pod_name" => CLOUDFUNCTIONS_POD_NAME,
+      "#{CONTAINER_SERVICE_NAME}/container_name" =>
+        CLOUDFUNCTIONS_CONTAINER_NAME,
       "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
       "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
       "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME
@@ -839,6 +877,32 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     end
   end
 
+  def test_one_cloudfunctions_log
+    setup_gce_metadata_stubs
+    setup_cloudfunctions_metadata_stubs
+    setup_logging_stubs
+    d = create_driver(APPLICATION_DEFAULT_CONFIG, CLOUDFUNCTIONS_TAG)
+    d.emit(cloudfunctions_log_entry(0))
+    d.run
+    verify_log_entries(1, CLOUDFUNCTIONS_PARAMS)
+  end
+
+  def test_multiple_cloudfunctions_logs
+    setup_gce_metadata_stubs
+    setup_cloudfunctions_metadata_stubs
+    setup_logging_stubs
+    d = create_driver(APPLICATION_DEFAULT_CONFIG, CLOUDFUNCTIONS_TAG)
+    [2, 3, 5, 11, 50].each do |n|
+      # The test driver doesn't clear its buffer of entries after running, so
+      # do it manually here.
+      d.instance_variable_get('@entries').clear
+      @logs_sent = []
+      n.times { |i| d.emit(cloudfunctions_log_entry(i)) }
+      d.run
+      verify_log_entries(n, CLOUDFUNCTIONS_PARAMS)
+    end
+  end
+
   # Make parse_severity public so we can test it.
   class Fluent::GoogleCloudOutput # rubocop:disable Style/ClassAndModuleChildren
     public :parse_severity
@@ -972,7 +1036,8 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def setup_logging_stubs
     [COMPUTE_PARAMS, VMENGINE_PARAMS, CONTAINER_FROM_TAG_PARAMS,
-     CONTAINER_FROM_METADATA_PARAMS, CUSTOM_PARAMS, EC2_PARAMS].each do |params|
+     CONTAINER_FROM_METADATA_PARAMS, CLOUDFUNCTIONS_PARAMS, CUSTOM_PARAMS,
+     EC2_PARAMS].each do |params|
       stub_request(:post, uri_for_log(params)).to_return do |request|
         @logs_sent << JSON.parse(request.body)
         { body: '' }
@@ -1024,6 +1089,17 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
                           'KUBE_BEARER_TOKEN: AoQiMuwkNP2BMT0S')
   end
 
+  def setup_cloudfunctions_metadata_stubs
+    stub_metadata_request(
+      'instance/attributes/',
+      "attribute1\nkube-env\ngcf_region\nlast_attribute")
+    stub_metadata_request('instance/attributes/kube-env',
+                          "ENABLE_NODE_LOGGING: \"true\"\n"\
+                          "INSTANCE_PREFIX: gke-gcf-cluster-1-740fdafa\n"\
+                          'KUBE_BEARER_TOKEN: AoQiMuwkNP2BMT0S')
+    stub_metadata_request('instance/attributes/gcf_region', 'us-central1')
+  end
+
   def container_log_entry_with_metadata(i)
     {
       message: log_entry(i),
@@ -1034,6 +1110,13 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
         pod_name: CONTAINER_POD_NAME,
         container_name: CONTAINER_CONTAINER_NAME
       }
+    }
+  end
+
+  def cloudfunctions_log_entry(i)
+    {
+      stream: 'stdout',
+      log: '[D][2015-09-25T12:34:56.789Z][123456789-0] ' + log_entry(i)
     }
   end
 


### PR DESCRIPTION
This way logs coming from functions are processed in a custom way, by extracting certain labels (function name, execution id) and fields (timestamp, severity) from tag name and log text, and marking the entries with Cloud Functions service name.

@mr-salty @rsokolowski