### PR TITLE
Use the Kubernetes container name as the log name rather than the tag.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -417,7 +417,8 @@ module Fluent
         # Don't send an empty request if we rejected all the entries.
         next if write_log_entries_request['entries'].empty?
 
-        log_name = CGI.escape(log_name(tag))
+        log_name = CGI.escape(
+          log_name(tag, write_log_entries_request['commonLabels']))
         url = 'https://logging.googleapis.com/v1beta3/projects/' \
           "#{@project_id}/logs/#{log_name}/entries:write"
         begin
@@ -664,13 +665,21 @@ module Fluent
       end
     end
 
-    def log_name(tag)
+    def log_name(tag, commonLabels)
       if @service_name == CLOUDFUNCTIONS_SERVICE
         return 'cloud-functions'
-      else
-        # Add a prefix to VMEngines logs to prevent namespace collisions.
-        return @running_on_managed_vm ? "#{APPENGINE_SERVICE}/#{tag}" : tag
+      elsif @running_on_managed_vm
+        # Add a prefix to Managed VM logs to prevent namespace collisions.
+        return "#{APPENGINE_SERVICE}/#{tag}"
+      elsif @service_name == CONTAINER_SERVICE
+        # For Kubernetes logs, use just the container name as the log name
+        # if we have it.
+        container_name_key = "#{CONTAINER_SERVICE}/container_name"
+        if commonLabels && commonLabels.key?(container_name_key)
+          return commonLabels[container_name_key]
+        end
       end
+      tag
     end
 
     def init_api_client

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -173,12 +173,12 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     }
   }
 
-  CONTAINER_LOG_NAME = "kubernetes.#{CONTAINER_POD_NAME}_" \
-                       "#{CONTAINER_NAMESPACE_NAME}_#{CONTAINER_CONTAINER_NAME}"
+  CONTAINER_TAG = "kubernetes.#{CONTAINER_POD_NAME}_" \
+                  "#{CONTAINER_NAMESPACE_NAME}_#{CONTAINER_CONTAINER_NAME}"
 
   CONTAINER_FROM_METADATA_PARAMS = {
     'service_name' => CONTAINER_SERVICE_NAME,
-    'log_name' => CONTAINER_LOG_NAME,
+    'log_name' => CONTAINER_CONTAINER_NAME,
     'project_id' => PROJECT_ID,
     'zone' => ZONE,
     'labels' => {
@@ -198,7 +198,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   # Almost the same as from metadata, but missing namespace_id and pod_id.
   CONTAINER_FROM_TAG_PARAMS = {
     'service_name' => CONTAINER_SERVICE_NAME,
-    'log_name' => CONTAINER_LOG_NAME,
+    'log_name' => CONTAINER_CONTAINER_NAME,
     'project_id' => PROJECT_ID,
     'zone' => ZONE,
     'labels' => {
@@ -850,7 +850,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     setup_gce_metadata_stubs
     setup_container_metadata_stubs
     setup_logging_stubs
-    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_LOG_NAME)
+    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_TAG)
     d.emit(container_log_entry_with_metadata(0))
     d.run
     verify_log_entries(1, CONTAINER_FROM_METADATA_PARAMS)
@@ -860,7 +860,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     setup_gce_metadata_stubs
     setup_container_metadata_stubs
     setup_logging_stubs
-    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_LOG_NAME)
+    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_TAG)
     [2, 3, 5, 11, 50].each do |n|
       # The test driver doesn't clear its buffer of entries after running, so
       # do it manually here.
@@ -876,7 +876,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     setup_gce_metadata_stubs
     setup_container_metadata_stubs
     setup_logging_stubs
-    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_LOG_NAME)
+    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_TAG)
     d.emit('message' => log_entry(0))
     d.run
     verify_log_entries(1, CONTAINER_FROM_TAG_PARAMS)
@@ -886,7 +886,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     setup_gce_metadata_stubs
     setup_container_metadata_stubs
     setup_logging_stubs
-    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_LOG_NAME)
+    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_TAG)
     [2, 3, 5, 11, 50].each do |n|
       # The test driver doesn't clear its buffer of entries after running, so
       # do it manually here.
@@ -962,7 +962,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     setup_gce_metadata_stubs
     setup_cloudfunctions_metadata_stubs
     setup_logging_stubs
-    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_LOG_NAME)
+    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_TAG)
     d.emit(cloudfunctions_log_entry(0))
     d.run
     verify_log_entries(1, CONTAINER_FROM_TAG_PARAMS, 'structPayload') do |entry|
@@ -977,7 +977,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     setup_gce_metadata_stubs
     setup_cloudfunctions_metadata_stubs
     setup_logging_stubs
-    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_LOG_NAME)
+    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_TAG)
     [2, 3, 5, 11, 50].each do |n|
       # The test driver doesn't clear its buffer of entries after running, so
       # do it manually here.


### PR DESCRIPTION
This prevents too many different log streams from being created for pods
in a replication controller, and allows for much better aggregation.

It could be confusing if people don't name their containers well, but in our experience most people tend to just name their container the same as the pod that it's in, and don't use meaningless names for them.

If it's alright, I'm going to be shortly following this up by also including whether it's stdout or stderr in the log name as well, making for names like "redis.stdout" and "redis.stderr" coming from a redis container. This'll also make it such that the payload can be just the log message, with no unnecessary json boilerplate. That'll take a little more surgery, though, since each batch of logs for the tag might have to be split into two different streams, which isn't supported at the moment.

@mr-salty 