### PR TITLE
Log a message containing the URL of the log viewer.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -272,6 +272,11 @@ module Fluent
         common_labels["#{COMPUTE_SERVICE}/resource_id"] = @vm_id
         common_labels["#{COMPUTE_SERVICE}/resource_name"] = @vm_name
       end
+
+      # Log an informational message containing the Logs viewer URL
+      @log.info 'Logs viewer address: ',
+                'https://console.developers.google.com/project/', @project_id,
+                '/logs?service=', @service_name, '&key1=instance&key2=', @vm_id
     end
 
     def start


### PR DESCRIPTION
This is currently done by the install script, but it is broken for
non-GCE platforms and is better done here, so it will also work for
people who don't use the install script.