### PR TITLE
Parse project_id from IAM account credentials.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -54,6 +54,10 @@ module Fluent
     # can be obtained from the metadata service or set explicitly.
     # Otherwise, the plugin will fail to initialize.
     #
+    # Note that while 'project id' properly refers to the alphanumeric name
+    # of the project, the logging service will also accept the project number,
+    # so either one is acceptable in this context.
+    #
     # Whether to attempt to obtain metadata from the local metadata service.
     # It is safe to specify 'true' even on platforms with no metadata service.
     config_param :use_metadata_service, :bool, :default => true
@@ -596,8 +600,8 @@ module Fluent
         nil
       end
 
-      # Extracts the project id from str.
-      # Returns the project ID (as a string) on success, or nil on failure.
+      # Extracts the project id (either name or number) from str and returns
+      # it (as a string) on success, or nil on failure.
       #
       # Recognizes IAM format (account@project-name.iam.gserviceaccount.com)
       # as well as the legacy format with a project number at the front of the

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -596,15 +596,20 @@ module Fluent
         nil
       end
 
-      # Extracts the project id from str.  Assumes the project ID is at the
-      # front of str, and consists of a string of digits terminated by a
-      # dash (-) which is not part of the project ID.  Example:
-      # 270694816269-1l1r2hb813leuppurdeik0apglbs80sv.apps.googleusercontent.com
+      # Extracts the project id from str.
       # Returns the project ID (as a string) on success, or nil on failure.
+      #
+      # Recognizes IAM format (account@project-name.iam.gserviceaccount.com)
+      # as well as the legacy format with a project number at the front of the
+      # string, terminated by a dash (-) which is not part of the ID, i.e.:
+      # 270694816269-1l1r2hb813leuppurdeik0apglbs80sv.apps.googleusercontent.com
       def self.extract_project_id(str)
-        @project_regexp = /^(?<project_id>\d+)-/
-        match_data = @project_regexp.match(str)
-        match_data ? match_data['project_id'] : nil
+        [/^.*@(?<project_id>.+)\.iam\.gserviceaccount\.com/,
+         /^(?<project_id>\d+)-/].each do |exp|
+          match_data = exp.match(str)
+          return match_data['project_id'] unless match_data.nil?
+        end
+        nil
       end
     end
 

--- a/test/plugin/data/iam-credentials.json
+++ b/test/plugin/data/iam-credentials.json
@@ -1,7 +1,11 @@
 {
-  "private_key_id": "cbedb7568906086cab57859bbfc1748749cc46c4",
+  "type": "service_account",
+  "private_key_id": "5985985bcdfe958895bd8d76456fe90d8484789d",
   "private_key": "-----BEGIN PRIVATE KEY-----\nMIICdwIBADANBgkqhkiG9w0BAQEcAASCAmEwggJdAgEAAoGBAKizy6B+aJ0Wua0e\njZ3pkHV0a2Ce1prJGhzGL5NpkbUjk6J11Kwp1yvPikTwALyy4PtUIZ+23D/unVRM\nHlKa2MkHIGjJg+mykX5Bd7eRJOxdJ0iu+eRWh7HiH+mdDntHwaz4xXihJBog71qS\n+9N+r2hy1hicybechchMiXHhmWPbAgMBAAECgYEAnSzeI4qCZxEcLtnPcXeBWpz7\nycpTAWUpycMvsjTiRxR9YRhM65YT3cJ//VhqJ2S1ThOcPCt/KqViuX4tpiKUo7qA\nH1AI9APbTo66wiGpgy+qG0wPJkKIQC8PpITNNcHqcbbAsIr3/XQduihsqxP2W2mT\na0nk5XJghs1Wa0xt28ECQQDgMqZjVDcDQyqM+bcBKJUUc/247KusjpdK70r6sx2o\nkZJGy/w9exlM5QrB6DLpw34/p5x4MoecZ7lS3yHdmaEhAkEAwKHsV4k5SXTUp4+J\nWK6GlQVvnwc+PQdX5gzt4/gWSY0Op5EQ+YD6cC7Lkz+GzXUzvmdp35c0ahS93D1/\nZLTZewJBAIjOc3cHMNadyr5BtulPEUE0ro+EY/GlBS8lu/QlDmkJg2AOI3qEvliM\nvza58S9yKny/U5yJAPVw2cZ3ABxQHeECQDyBX8PrBURuXvE2o5RoVTtvlqziAi3X\nJaPLwdkOLqnxlX3KkgNcoM0l1amtlYDpZcRVcSs0+9TqKOyJoH8YUwsCQA4cJmv3\n119xcijXPM2HZOB5cCxTHj59MRtQlLboNZ2witDCJ20eG9AC3ZcH7csS0H9dz8Jr\nXGEoQMPD2ck4T0U\u003d\n-----END PRIVATE KEY-----\n",
-  "client_email": "847859579879-q8ancssppuvtv8dac0i742pslde81jgl@developer.gserviceaccount.com",
-  "client_id": "847859579879-q8ancssppuvtv8dac0i742pslde81jgl.apps.googleusercontent.com",
-  "type": "service_account"
+  "client_email": "account-name@fluent-test-project.iam.gserviceaccount.com",
+  "client_id": "275859789789367827863",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/account-name%40fluent-test-project.iam.gserviceaccount.com"
 }


### PR DESCRIPTION
This new credentials format is currently rolling out to all users; the
email address format is account@project-id.iam.gserviceaccount.com.
The existing format is still supported.