### PR TITLE
Support encoded names of cloud functions and set service name properly

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -313,18 +313,6 @@ module Fluent
           'commonLabels' => @common_labels,
           'entries' => []
         }
-        if @service_name == CONTAINER_SERVICE && @compiled_kubernetes_tag_regexp
-          # Container logs in Kubernetes are tagged based on where they came
-          # from, so we can extract useful metadata from the tag.
-          # Do this here to avoid having to repeat it for each record.
-          match_data = @compiled_kubernetes_tag_regexp.match(tag)
-          if match_data
-            labels = write_log_entries_request['commonLabels']
-            %w(namespace_name pod_name container_name).each do |field|
-              labels["#{CONTAINER_SERVICE}/#{field}"] = match_data[field]
-            end
-          end
-        end
         if @running_cloudfunctions
           # If the current group of entries is coming from a Cloud Functions
           # function, the function name can be extracted from the tag.
@@ -341,6 +329,19 @@ module Fluent
             # Other logs are considered as coming from the Container Engine
             # service.
             @service_name = CONTAINER_SERVICE
+          end
+        end
+        if [CONTAINER_SERVICE, CLOUDFUNCTIONS_SERVICE]
+           .include?(@service_name) && @compiled_kubernetes_tag_regexp
+          # Container logs in Kubernetes are tagged based on where they came
+          # from, so we can extract useful metadata from the tag.
+          # Do this here to avoid having to repeat it for each record.
+          match_data = @compiled_kubernetes_tag_regexp.match(tag)
+          if match_data
+            labels = write_log_entries_request['commonLabels']
+            %w(namespace_name pod_name container_name).each do |field|
+              labels["#{CONTAINER_SERVICE}/#{field}"] = match_data[field]
+            end
           end
         end
         is_container_json = nil

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -332,8 +332,7 @@ module Fluent
             @service_name = CONTAINER_SERVICE
           end
         end
-        if [CONTAINER_SERVICE, CLOUDFUNCTIONS_SERVICE]
-           .include?(@service_name) && @compiled_kubernetes_tag_regexp
+        if @service_name == CONTAINER_SERVICE && @compiled_kubernetes_tag_regexp
           # Container logs in Kubernetes are tagged based on where they came
           # from, so we can extract useful metadata from the tag.
           # Do this here to avoid having to repeat it for each record.

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -251,11 +251,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       "#{CLOUDFUNCTIONS_SERVICE_NAME}/region" => CLOUDFUNCTIONS_REGION,
       "#{CONTAINER_SERVICE_NAME}/instance_id" => VM_ID,
       "#{CONTAINER_SERVICE_NAME}/cluster_name" => CLOUDFUNCTIONS_CLUSTER_NAME,
-      "#{CONTAINER_SERVICE_NAME}/namespace_name" =>
-        CLOUDFUNCTIONS_NAMESPACE_NAME,
-      "#{CONTAINER_SERVICE_NAME}/pod_name" => CLOUDFUNCTIONS_POD_NAME,
-      "#{CONTAINER_SERVICE_NAME}/container_name" =>
-        CLOUDFUNCTIONS_CONTAINER_NAME,
       "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
       "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
       "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME
@@ -273,11 +268,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       "#{CLOUDFUNCTIONS_SERVICE_NAME}/region" => CLOUDFUNCTIONS_REGION,
       "#{CONTAINER_SERVICE_NAME}/instance_id" => VM_ID,
       "#{CONTAINER_SERVICE_NAME}/cluster_name" => CLOUDFUNCTIONS_CLUSTER_NAME,
-      "#{CONTAINER_SERVICE_NAME}/namespace_name" =>
-        CLOUDFUNCTIONS_NAMESPACE_NAME,
-      "#{CONTAINER_SERVICE_NAME}/pod_name" => CLOUDFUNCTIONS_POD_NAME,
-      "#{CONTAINER_SERVICE_NAME}/container_name" =>
-        CLOUDFUNCTIONS_CONTAINER_NAME,
       "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
       "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
       "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -72,12 +72,12 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   CONTAINER_STREAM = 'stdout'
 
   # Cloud Functions specific labels
-  CLOUDFUNCTIONS_FUNCTION_NAME = 'function-1'
+  CLOUDFUNCTIONS_FUNCTION_NAME = '$My_Function.Name-@1'
   CLOUDFUNCTIONS_REGION = 'us-central1'
   CLOUDFUNCTIONS_EXECUTION_ID = '123-0'
   CLOUDFUNCTIONS_CLUSTER_NAME = 'cluster-1'
   CLOUDFUNCTIONS_NAMESPACE_NAME = 'default'
-  CLOUDFUNCTIONS_POD_NAME = "#{CLOUDFUNCTIONS_FUNCTION_NAME}.987-c0l82"
+  CLOUDFUNCTIONS_POD_NAME = 'd.dc.myu.uc.functionp.pc.name-a.a1.987-c0l82'
   CLOUDFUNCTIONS_CONTAINER_NAME = 'worker'
 
   # Parameters used for authentication


### PR DESCRIPTION
Adding support for encoded function names extracted from a tag. Updating the Cloud Functions tag regexp to reflect the expected format.

Moving the block which sets current service name when running Cloud Functions before the name is read.

@mr-salty 