### PR TITLE
Add a severity parsing mapping from "F" to "CRITICAL".

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -592,6 +592,7 @@ module Fluent
       'W' => 'WARNING',
       'E' => 'ERROR',
       'C' => 'CRITICAL',
+      'F' => 'CRITICAL',
       'A' => 'ALERT',
       # other misc. translations.
       'ERR' => 'ERROR'

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -1054,6 +1054,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     assert_equal('ERROR', test_obj.parse_severity('E'))
     assert_equal('CRITICAL', test_obj.parse_severity('C'))
     assert_equal('ALERT', test_obj.parse_severity('A'))
+    assert_equal('CRITICAL', test_obj.parse_severity('F'))
     assert_equal('ERROR', test_obj.parse_severity('e'))
 
     assert_equal('DEFAULT', test_obj.parse_severity('x'))


### PR DESCRIPTION
It should really map to FATAL, but that doesn't seem to be an option in
the API. For what it's worth, fatal is the highest log level in:
https://github.com/google/glog
https://golang.org/pkg/log/

@mr-salty 