### PR TITLE
Require Ruby version 2.0 or greater.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.2
   - 2.0.0
   - 2.1
-  - 1.9.3
 script: "bundle exec rake"
 before_install:
  - gem update bundler

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -17,7 +17,7 @@ eos
   gem.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
-  gem.required_ruby_version = Gem::Requirement.new(">= 2.0")
+  gem.required_ruby_version = Gem::Requirement.new('>= 2.0')
 
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'google-api-client', '>= 0.8.6', '< 0.9'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -17,14 +17,12 @@ eos
   gem.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
+  gem.required_ruby_version = Gem::Requirement.new(">= 2.0")
 
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'google-api-client', '>= 0.8.6', '< 0.9'
   gem.add_runtime_dependency 'googleauth', '~> 0.4'
   gem.add_runtime_dependency 'json', '~> 1.8'
-  # workaround for jwt 1.5.3 breaking ruby 1.9 support (included by googleauth)
-  # see https://github.com/jwt/ruby-jwt/issues/132
-  gem.add_runtime_dependency 'jwt', '< 1.5.3'
 
   gem.add_development_dependency 'mocha', '~> 1.1'
   gem.add_development_dependency 'rake', '~> 10.3'


### PR DESCRIPTION
Maintaining support for 1.9 has become a chore, and it's been
offically EOL for over a year.

The upcoming fluentd-0.14 will also drop support for ruby 1.9.