### PR TITLE
Update to rubocop 0.35

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -13,13 +13,11 @@ eos
   gem.version       = '0.4.16'
   gem.authors       = ['Todd Derr', 'Alex Robinson']
   gem.email         = ['salty@google.com']
-
   gem.required_ruby_version = Gem::Requirement.new('>= 2.0')
 
   gem.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
-  gem.required_ruby_version = Gem::Requirement.new('>= 2.0')
 
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'google-api-client', '> 0.9'
@@ -28,7 +26,7 @@ eos
 
   gem.add_development_dependency 'mocha', '~> 1.1'
   gem.add_development_dependency 'rake', '~> 10.3'
-  gem.add_development_dependency 'rubocop', '= 0.34.2'
+  gem.add_development_dependency 'rubocop', '= 0.35.0'
   gem.add_development_dependency 'webmock', '~> 1.17'
   gem.add_development_dependency 'test-unit', '~> 3.0'
 end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -486,11 +486,11 @@ module Fluent
 
       begin
         open('http://' + METADATA_SERVICE_ADDR) do |f|
-          if (f.meta['metadata-flavor'] == 'Google')
+          if f.meta['metadata-flavor'] == 'Google'
             @log.info 'Detected GCE platform'
             return Platform::GCE
           end
-          if (f.meta['server'] == 'EC2ws')
+          if f.meta['server'] == 'EC2ws'
             @log.info 'Detected EC2 platform'
             return Platform::EC2
           end
@@ -765,7 +765,7 @@ module Fluent
       end
     end
 
-    def log_name(tag, commonLabels)
+    def log_name(tag, common_labels)
       if @service_name == CLOUDFUNCTIONS_SERVICE
         return 'cloud-functions'
       elsif @running_on_managed_vm
@@ -775,8 +775,8 @@ module Fluent
         # For Kubernetes logs, use just the container name as the log name
         # if we have it.
         container_name_key = "#{CONTAINER_SERVICE}/container_name"
-        if commonLabels && commonLabels.key?(container_name_key)
-          return commonLabels[container_name_key]
+        if common_labels && common_labels.key?(container_name_key)
+          return common_labels[container_name_key]
         end
       end
       tag

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -1313,7 +1313,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
           assert entry.key?(payload_type), 'Entry did not contain expected ' \
             "#{payload_type} key: " + entry.to_s
           # Check the payload for textPayload, otherwise it's up to the caller.
-          if (payload_type == 'textPayload')
+          if payload_type == 'textPayload'
             assert_equal "test log entry #{i}", entry['textPayload'], batch
           end
         end


### PR DESCRIPTION
* Fix newly introduced warnings (extra parens, variable case)
* also remove a renundant required_ruby_version that crept in.