### PR TITLE
Detect JSON by checking each line, in all ingested logs

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -333,7 +333,6 @@ module Fluent
             end
           end
         end
-        is_container_json = nil
         arr.each do |time, record|
           next unless record.is_a?(Hash)
 
@@ -359,25 +358,20 @@ module Fluent
             if record.key?('kubernetes')
               handle_container_metadata(record, entry)
             end
-            # If the log from the user container is json, we want to export it
-            # as a structured log. Now that we've pulled out all the
-            # container-specific metadata from the record, we can replace the
-            # record with the json that the user logged.
-            # To save CPU in the common case of unstructured logs, only check if
-            # the contents are parsable as json for the first entry of each
-            # batch.
-            if is_container_json.nil? && record.key?('log')
-              record_json = parse_json_or_nil(record['log'])
-              if record_json.nil?
-                is_container_json = false
-              else
-                record = record_json
-                is_container_json = true
-              end
-            elsif is_container_json && record.key?('log')
-              record_json = parse_json_or_nil(record['log'])
-              record = record_json unless record_json.nil?
-            end
+          end
+
+          # If the log is json, we want to export it as a structured log unless
+          # there is additional metadata that would be lost.
+          is_json = false
+          if record.length == 1 && record.key?('log')
+            record_json = parse_json_or_nil(record['log'])
+          end
+          if record.length == 1 && record.key?('message')
+            record_json = parse_json_or_nil(record['message'])
+          end
+          unless record_json.nil?
+            record = record_json
+            is_json = true
           end
 
           set_timestamp(record, entry, time)
@@ -400,7 +394,7 @@ module Fluent
               @cloudfunctions_log_match['execution_id']
           end
 
-          set_payload(record, entry, is_container_json)
+          set_payload(record, entry, is_json)
           entry.metadata.labels = nil if entry.metadata.labels.empty?
 
           entries.push(entry)
@@ -462,11 +456,23 @@ module Fluent
       # Only here to please rubocop...
       return nil if input.nil?
 
-      begin
-        return JSON.parse(input)
-      rescue JSON::ParserError
-        return nil
-      end
+      input.each_codepoint do |c|
+        if c == 123
+          # left curly bracket (U+007B)
+          begin
+            return JSON.parse(input)
+          rescue JSON::ParserError
+            return nil
+          end
+        else
+          # Break (and return nil) unless the current character is whitespace,
+          # in which case we continue to look for a left curly bracket.
+          # Whitespace as per the JSON spec are: tabulation (U+0009),
+          # line feed (U+000A), carriage return (U+000D), and space (U+0020).
+          break unless c == 9 || c == 10 || c == 13 || c == 32
+        end # case
+      end # do
+      return nil
     end
 
     # "enum" of Platform values
@@ -745,18 +751,20 @@ module Fluent
       record.delete(field)
     end
 
-    def set_payload(record, entry, is_container_json)
+    def set_payload(record, entry, is_json)
       # Use textPayload if
-      # 1. This is a Cloud Functions log that matched the expected regexp
-      # 2. This is a Cloud Functions log and the 'log' key is available
-      # 3. This is an unstructured Container log and the 'log' key is available
-      # 4. The only remaining key is 'message'
-      if @service_name == CLOUDFUNCTIONS_SERVICE && @cloudfunctions_log_match
+      # 1. The log was not valid JSON
+      # 2. This is a Cloud Functions log that matched the expected regexp
+      # 3. This is a Cloud Functions log and the 'log' key is available
+      # 4. This is an unstructured Container log and the 'log' key is available
+      # 5. The only remaining key is 'message'
+      if is_json
+        entry.struct_payload = record
+      elsif @service_name == CLOUDFUNCTIONS_SERVICE && @cloudfunctions_log_match
         entry.text_payload = @cloudfunctions_log_match['text']
       elsif @service_name == CLOUDFUNCTIONS_SERVICE && record.key?('log')
         entry.text_payload = record['log']
-      elsif @service_name == CONTAINER_SERVICE && record.key?('log') &&
-            !is_container_json
+      elsif @service_name == CONTAINER_SERVICE && record.key?('log')
         entry.text_payload = record['log']
       elsif record.size == 1 && record.key?('message')
         entry.text_payload = record['message']

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -472,7 +472,7 @@ module Fluent
           break unless c == 9 || c == 10 || c == 13 || c == 32
         end # case
       end # do
-      return nil
+      nil
     end
 
     # "enum" of Platform values

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -752,12 +752,11 @@ module Fluent
     end
 
     def set_payload(record, entry, is_json)
-      # Use textPayload if
-      # 1. The log was not valid JSON
-      # 2. This is a Cloud Functions log that matched the expected regexp
-      # 3. This is a Cloud Functions log and the 'log' key is available
-      # 4. This is an unstructured Container log and the 'log' key is available
-      # 5. The only remaining key is 'message'
+      # Use text payload if the log was not valid JSON and:
+      # 1. This is a Cloud Functions log that matched the expected regexp
+      # 2. This is a Cloud Functions log and the 'log' key is available
+      # 3. This is an unstructured Container log and the 'log' key is available
+      # 4. The only remaining key is 'message'
       if is_json
         entry.struct_payload = record
       elsif @service_name == CLOUDFUNCTIONS_SERVICE && @cloudfunctions_log_match

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -599,7 +599,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       if log_index == 1
         assert entry.key?('textPayload'), 'Entry did not have textPayload'
       else
-        assert entry.key?('structPayload'),  'Entry did not have structPayload'
+        assert entry.key?('structPayload'), 'Entry did not have structPayload'
         assert_equal 3, entry['structPayload'].size, entry
         assert_equal 'test log entry 0', entry['structPayload']['msg'], entry
         assert_equal 'test', entry['structPayload']['tag2'], entry
@@ -624,7 +624,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       if log_index == 1
         assert entry.key?('textPayload'), 'Entry did not have textPayload'
       else
-        assert entry.key?('structPayload'),  'Entry did not have structPayload'
+        assert entry.key?('structPayload'), 'Entry did not have structPayload'
         assert_equal 3, entry['structPayload'].size, entry
         assert_equal 'test log entry 0', entry['structPayload']['msg'], entry
         assert_equal 'test', entry['structPayload']['tag2'], entry


### PR DESCRIPTION
Instead of just checking the first line of each batch, check every line
for structured content in JSON format, for all ingested logs and not
just for logs coming from containers. This makes the logic easier to
understand and explain to users, and more uniform across the different
logs sources. The implementation now checks whether the start of the
line is valid JSON using simple string operations. Overall, assuming
that most batches of log lines are not JSON-formatted and have a
relatively low number of lines in the batch, this change should result
in less CPU compared to the old implementation which calls JSON.parse
and uses rescue to recover.