### PR TITLE
For k8s/Docker, use the stream to determine severity.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -660,6 +660,16 @@ module Fluent
       elsif record.key?('severity')
         entry.metadata.severity = parse_severity(record['severity'])
         record.delete('severity')
+      elsif @service_name == CONTAINER_SERVICE && \
+            entry.metadata.labels.key?("#{CONTAINER_SERVICE}/stream")
+        stream = entry.metadata.labels["#{CONTAINER_SERVICE}/stream"]
+        if stream == 'stdout'
+          entry.metadata.severity = 'INFO'
+        elsif stream == 'stderr'
+          entry.metadata.severity = 'ERROR'
+        else
+          entry.metadata.severity = 'DEFAULT'
+        end
       else
         entry.metadata.severity = 'DEFAULT'
       end


### PR DESCRIPTION
Set the severity to INFO for log messages coming from stdout,
and to ERROR for stderr.

No new code here, just a rebased version of @bokowski's #70

@igorpeshansky 