### PR TITLE
Detect JSON by checking each line, in all ingested logs

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -375,8 +375,10 @@ module Fluent
             end
           end
 
-          # Save the timestamp if available
+          # Save the timestamp if available, then clear it out to allow for
+          # determining whether we should parse the log or message field.
           timestamp = record.key?('time') ? record['time'] : nil
+          record.delete('time')
           # If the log is json, we want to export it as a structured log unless
           # there is additional metadata that would be lost.
           is_json = false

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -348,7 +348,6 @@ module Fluent
             end
           end
         end
-        is_container_json = nil
         arr.each do |time, record|
           next unless record.is_a?(Hash)
 
@@ -374,31 +373,26 @@ module Fluent
             if record.key?('kubernetes')
               handle_container_metadata(record, entry)
             end
-            # Save the timestamp if available
-            timestamp = record.key?('time') ? record['time'] : nil
-            # If the log from the user container is json, we want to export it
-            # as a structured log. Now that we've pulled out all the
-            # container-specific metadata from the record, we can replace the
-            # record with the json that the user logged.
-            # To save CPU in the common case of unstructured logs, only check if
-            # the contents are parsable as json for the first entry of each
-            # batch.
-            if is_container_json.nil? && record.key?('log')
-              record_json = parse_json_or_nil(record['log'])
-              if record_json.nil?
-                is_container_json = false
-              else
-                record = record_json
-                is_container_json = true
-              end
-            elsif is_container_json && record.key?('log')
-              record_json = parse_json_or_nil(record['log'])
-              record = record_json unless record_json.nil?
-            end
-            # Restore timestamp if necessary
-            unless record.key?('time') || timestamp.nil?
-              record['time'] = timestamp
-            end
+          end
+
+          # Save the timestamp if available
+          timestamp = record.key?('time') ? record['time'] : nil
+          # If the log is json, we want to export it as a structured log unless
+          # there is additional metadata that would be lost.
+          is_json = false
+          if record.length == 1 && record.key?('log')
+            record_json = parse_json_or_nil(record['log'])
+          end
+          if record.length == 1 && record.key?('message')
+            record_json = parse_json_or_nil(record['message'])
+          end
+          unless record_json.nil?
+            record = record_json
+            is_json = true
+          end
+          # Restore timestamp if necessary
+          unless record.key?('time') || timestamp.nil?
+            record['time'] = timestamp
           end
 
           set_timestamp(record, entry, time)
@@ -421,7 +415,7 @@ module Fluent
               @cloudfunctions_log_match['execution_id']
           end
 
-          set_payload(record, entry, is_container_json)
+          set_payload(record, entry, is_json)
           entry.metadata.labels = nil if entry.metadata.labels.empty?
 
           entries.push(entry)
@@ -483,11 +477,23 @@ module Fluent
       # Only here to please rubocop...
       return nil if input.nil?
 
-      begin
-        return JSON.parse(input)
-      rescue JSON::ParserError
-        return nil
-      end
+      input.each_codepoint do |c|
+        if c == 123
+          # left curly bracket (U+007B)
+          begin
+            return JSON.parse(input)
+          rescue JSON::ParserError
+            return nil
+          end
+        else
+          # Break (and return nil) unless the current character is whitespace,
+          # in which case we continue to look for a left curly bracket.
+          # Whitespace as per the JSON spec are: tabulation (U+0009),
+          # line feed (U+000A), carriage return (U+000D), and space (U+0020).
+          break unless c == 9 || c == 10 || c == 13 || c == 32
+        end # case
+      end # do
+      nil
     end
 
     # "enum" of Platform values
@@ -775,18 +781,20 @@ module Fluent
       record.delete(field)
     end
 
-    def set_payload(record, entry, is_container_json)
-      # Use textPayload if
-      # 1. This is a Cloud Functions log that matched the expected regexp
-      # 2. This is a Cloud Functions log and the 'log' key is available
-      # 3. This is an unstructured Container log and the 'log' key is available
-      # 4. The only remaining key is 'message'
+    def set_payload(record, entry, is_json)
+      # If this is a Cloud Functions log that matched the expected regexp,
+      # use text payload. Otherwise, use JSON if we found valid JSON, or text
+      # payload in the following cases:
+      # 1. This is a Cloud Functions log and the 'log' key is available
+      # 2. This is an unstructured Container log and the 'log' key is available
+      # 3. The only remaining key is 'message'
       if @service_name == CLOUDFUNCTIONS_SERVICE && @cloudfunctions_log_match
         entry.text_payload = @cloudfunctions_log_match['text']
       elsif @service_name == CLOUDFUNCTIONS_SERVICE && record.key?('log')
         entry.text_payload = record['log']
-      elsif @service_name == CONTAINER_SERVICE && record.key?('log') &&
-            !is_container_json
+      elsif is_json
+        entry.struct_payload = record
+      elsif @service_name == CONTAINER_SERVICE && record.key?('log')
         entry.text_payload = record['log']
       elsif record.size == 1 && record.key?('message')
         entry.text_payload = record['message']

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -588,6 +588,56 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     end
   end
 
+  def test_struct_payload_json_log
+    setup_gce_metadata_stubs
+    setup_logging_stubs
+    d = create_driver
+    json_string = '{"msg": "test log entry 0", "tag2": "test", "data": 5000}'
+    d.emit('message' => 'notJSON ' + json_string)
+    d.emit('message' => json_string)
+    d.emit('message' => "\t" + json_string)
+    d.emit('message' => '  ' + json_string)
+    d.run
+    log_index = 0
+    verify_log_entries(4, COMPUTE_PARAMS, '') do |entry|
+      log_index += 1
+      if log_index == 1
+        assert entry.key?('textPayload'), 'Entry did not have textPayload'
+      else
+        assert entry.key?('structPayload'), 'Entry did not have structPayload'
+        assert_equal 3, entry['structPayload'].size, entry
+        assert_equal 'test log entry 0', entry['structPayload']['msg'], entry
+        assert_equal 'test', entry['structPayload']['tag2'], entry
+        assert_equal 5000, entry['structPayload']['data'], entry
+      end
+    end
+  end
+
+  def test_struct_payload_json_container_log
+    setup_gce_metadata_stubs
+    setup_container_metadata_stubs
+    setup_logging_stubs
+    d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_TAG)
+    json_string = '{"msg": "test log entry 0", "tag2": "test", "data": 5000}'
+    d.emit(container_log_entry_with_metadata('notJSON' + json_string))
+    d.emit(container_log_entry_with_metadata(json_string))
+    d.emit(container_log_entry_with_metadata("  \r\n \t" + json_string))
+    d.run
+    log_index = 0
+    verify_log_entries(3, CONTAINER_FROM_METADATA_PARAMS, '') do |entry|
+      log_index += 1
+      if log_index == 1
+        assert entry.key?('textPayload'), 'Entry did not have textPayload'
+      else
+        assert entry.key?('structPayload'), 'Entry did not have structPayload'
+        assert_equal 3, entry['structPayload'].size, entry
+        assert_equal 'test log entry 0', entry['structPayload']['msg'], entry
+        assert_equal 'test', entry['structPayload']['tag2'], entry
+        assert_equal 5000, entry['structPayload']['data'], entry
+      end
+    end
+  end
+
   def test_timestamps
     setup_gce_metadata_stubs
     setup_logging_stubs


### PR DESCRIPTION
This takes @bokowski's #65, resolves the merge conflict with the other PRs that have gone in recently, and fixes the broken tests from #65 by removing the time field from the record while checking for json. That's needed because we don't attempt to parse json if the record itself has multiple fields in it. The time is re-added after the json parsing if needed, as implemented by #69.

@igorpeshansky - I believe this is good to go, with just the one line change on top of #65.