### PR TITLE
Map NGINX error log levels

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -728,7 +728,7 @@ module Fluent
       'ERR' => 'ERROR',
       'F' => 'CRITICAL',
       'CRIT' => 'CRITICAL',
-      'EMERG' => 'CRITICAL'
+      'EMERG' => 'EMERGENCY'
     }
 
     def parse_severity(severity_str)

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -716,6 +716,9 @@ module Fluent
       'FINE' => 'DEBUG',
       'FINER' => 'DEBUG',
       'FINEST' => 'DEBUG',
+      # nginx levels (only missing ones listed).
+      'CRIT' => 'CRITICAL',
+      'EMERG' => 'EMERGENCY',
       # single-letter levels.  Note E->ERROR and D->DEBUG.
       'D' => 'DEBUG',
       'I' => 'INFO',
@@ -726,9 +729,7 @@ module Fluent
       'A' => 'ALERT',
       # other misc. translations.
       'ERR' => 'ERROR',
-      'F' => 'CRITICAL',
-      'CRIT' => 'CRITICAL',
-      'EMERG' => 'EMERGENCY'
+      'F' => 'CRITICAL'
     }
 
     def parse_severity(severity_str)

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -726,7 +726,9 @@ module Fluent
       'A' => 'ALERT',
       # other misc. translations.
       'ERR' => 'ERROR',
-      'F' => 'CRITICAL'
+      'F' => 'CRITICAL',
+      'CRIT' => 'CRITICAL',
+      'EMERG' => 'CRITICAL'
     }
 
     def parse_severity(severity_str)

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -716,7 +716,7 @@ module Fluent
       'FINE' => 'DEBUG',
       'FINER' => 'DEBUG',
       'FINEST' => 'DEBUG',
-      # nginx levels (only missing ones listed).
+      # nginx levels (only missing ones from above listed).
       'CRIT' => 'CRITICAL',
       'EMERG' => 'EMERGENCY',
       # single-letter levels.  Note E->ERROR and D->DEBUG.


### PR DESCRIPTION
This enables Cloud Logging to parse NGINX's [`error.log`](https://www.nginx.com/resources/admin-guide/logging-and-monitoring/) files.