### PR TITLE
parse json for EC2_SERVICE as well

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -363,10 +363,12 @@ module Fluent
             @cloudfunctions_log_match =
               @cloudfunctions_log_regexp.match(record['log'])
           end
-          if @service_name == CONTAINER_SERVICE
-            # Move the stdout/stderr annotation from the record into a label
-            field_to_label(record, 'stream', entry.metadata.labels,
-                           "#{CONTAINER_SERVICE}/stream")
+          if @service_name == CONTAINER_SERVICE || @service_name == EC2_SERVICE
+            if @service_name == CONTAINER_SERVICE
+              # Move the stdout/stderr annotation from the record into a label
+              field_to_label(record, 'stream', entry.metadata.labels,
+                             "#{CONTAINER_SERVICE}/stream")
+            end
             # If the record has been annotated by the kubernetes_metadata_filter
             # plugin, then use that metadata. Otherwise, rely on commonLabels
             # populated at the grouped_entries level from the group's tag.


### PR DESCRIPTION
JSON logs from EC2 instances are not getting parsed and are displayed as `textPayload` in Log Viewer.

This PR tries to parse JSON logs for EC2 instances.