### PR TITLE
Migrate to Logging API v2beta1

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 1300
+  Max: 1400
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -363,7 +363,7 @@ module Fluent
         resource = @resource
         entries = []
         # Note that we assume that labels added to common_labels below are not
-        # 'service' labels (i.e. we do not call extract_resource_labels again)
+        # 'service' labels (i.e. we do not call extract_resource_labels again).
         common_labels = @common_labels
 
         if @running_cloudfunctions
@@ -379,7 +379,8 @@ module Fluent
             resource.labels['function_name'] =
               decode_cloudfunctions_function_name(
                 match_data['encoded_function_name'])
-            # Move labels from the MonitoredResource to the LogEntry.
+            # Move GKE container labels from the MonitoredResource to the
+            # LogEntry.
             instance_id = resource.labels.delete('instance_id')
             common_labels = common_labels.dup
             common_labels["#{CONTAINER_SERVICE}/cluster_name"] =
@@ -897,7 +898,7 @@ module Fluent
       tag
     end
 
-    # Some services set labels (via configuring 'labels' or 'label_map' which
+    # Some services set labels (via configuring 'labels' or 'label_map') which
     # are now MonitoredResource labels in v2.
     # For these services, remove resource labels from 'labels' and return a
     # Hash of labels to be merged into the MonitoredResource labels.

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -41,6 +41,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   # generic attributes
   HOSTNAME = Socket.gethostname
+  WRITE_LOG_ENTRIES_URI = 'https://logging.googleapis.com/v2beta1/entries:write'
 
   # attributes used for the GCE metadata service
   PROJECT_ID = 'test-project-id'
@@ -176,29 +177,37 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   CLOUDFUNCTIONS_SERVICE_NAME = 'cloudfunctions.googleapis.com'
   EC2_SERVICE_NAME = 'ec2.amazonaws.com'
 
+  COMPUTE_RESOURCE_TYPE = 'gce_instance'
+
   COMPUTE_PARAMS = {
-    service_name: COMPUTE_SERVICE_NAME,
+    resource: {
+      type: 'gce_instance',
+      labels: {
+        'instance_id' => VM_ID,
+        'zone' => ZONE
+      }
+    },
     log_name: 'test',
     project_id: PROJECT_ID,
-    zone: ZONE,
     labels: {
-      "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
-      "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
       "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME
     }
   }
 
   VMENGINE_PARAMS = {
-    service_name: APPENGINE_SERVICE_NAME,
-    log_name: "#{APPENGINE_SERVICE_NAME}%2Ftest",
+    resource: {
+      type: 'gae_app',
+      labels: {
+        'module_id' => MANAGED_VM_BACKEND_NAME,
+        'version_id' => MANAGED_VM_BACKEND_VERSION
+      }
+    },
+    log_name: "#{APPENGINE_SERVICE_NAME}/test",
     project_id: PROJECT_ID,
-    zone: ZONE,
     labels: {
-      "#{APPENGINE_SERVICE_NAME}/module_id" => MANAGED_VM_BACKEND_NAME,
-      "#{APPENGINE_SERVICE_NAME}/version_id" => MANAGED_VM_BACKEND_VERSION,
-      "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
       "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
-      "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME
+      "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME,
+      "#{COMPUTE_SERVICE_NAME}/zone" => ZONE
     }
   }
 
@@ -206,41 +215,45 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
                   "#{CONTAINER_NAMESPACE_NAME}_#{CONTAINER_CONTAINER_NAME}"
 
   CONTAINER_FROM_METADATA_PARAMS = {
-    service_name: CONTAINER_SERVICE_NAME,
+    resource: {
+      type: 'container',
+      labels: {
+        'cluster_name' => CONTAINER_CLUSTER_NAME,
+        'namespace_id' => CONTAINER_NAMESPACE_ID,
+        'instance_id' => VM_ID,
+        'pod_id' => CONTAINER_POD_ID,
+        'container_name' => CONTAINER_CONTAINER_NAME,
+        'zone' => ZONE
+      }
+    },
     log_name: CONTAINER_CONTAINER_NAME,
     project_id: PROJECT_ID,
-    zone: ZONE,
     labels: {
-      "#{CONTAINER_SERVICE_NAME}/instance_id" => VM_ID,
-      "#{CONTAINER_SERVICE_NAME}/cluster_name" => CONTAINER_CLUSTER_NAME,
       "#{CONTAINER_SERVICE_NAME}/namespace_name" => CONTAINER_NAMESPACE_NAME,
-      "#{CONTAINER_SERVICE_NAME}/namespace_id" => CONTAINER_NAMESPACE_ID,
       "#{CONTAINER_SERVICE_NAME}/pod_name" => CONTAINER_POD_NAME,
-      "#{CONTAINER_SERVICE_NAME}/pod_id" => CONTAINER_POD_ID,
-      "#{CONTAINER_SERVICE_NAME}/container_name" => CONTAINER_CONTAINER_NAME,
       "#{CONTAINER_SERVICE_NAME}/stream" => CONTAINER_STREAM,
       "label/#{CONTAINER_LABEL_KEY}" => CONTAINER_LABEL_VALUE,
-      "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
-      "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
       "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME
     }
   }
 
   # Almost the same as from metadata, but missing namespace_id and pod_id.
   CONTAINER_FROM_TAG_PARAMS = {
-    service_name: CONTAINER_SERVICE_NAME,
+    resource: {
+      type: 'container',
+      labels: {
+        'cluster_name' => CONTAINER_CLUSTER_NAME,
+        'instance_id' => VM_ID,
+        'container_name' => CONTAINER_CONTAINER_NAME,
+        'zone' => ZONE
+      }
+    },
     log_name: CONTAINER_CONTAINER_NAME,
     project_id: PROJECT_ID,
-    zone: ZONE,
     labels: {
-      "#{CONTAINER_SERVICE_NAME}/instance_id" => VM_ID,
-      "#{CONTAINER_SERVICE_NAME}/cluster_name" => CONTAINER_CLUSTER_NAME,
       "#{CONTAINER_SERVICE_NAME}/namespace_name" => CONTAINER_NAMESPACE_NAME,
       "#{CONTAINER_SERVICE_NAME}/pod_name" => CONTAINER_POD_NAME,
-      "#{CONTAINER_SERVICE_NAME}/container_name" => CONTAINER_CONTAINER_NAME,
       "#{CONTAINER_SERVICE_NAME}/stream" => CONTAINER_STREAM,
-      "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
-      "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
       "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME
     }
   }
@@ -250,64 +263,76 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
                         "#{CLOUDFUNCTIONS_CONTAINER_NAME}"
 
   CLOUDFUNCTIONS_PARAMS = {
-    service_name: CLOUDFUNCTIONS_SERVICE_NAME,
+    resource: {
+      type: 'cloud_function',
+      labels: {
+        'function_name' => CLOUDFUNCTIONS_FUNCTION_NAME,
+        'region' => CLOUDFUNCTIONS_REGION
+      }
+    },
     log_name: 'cloud-functions',
     project_id: PROJECT_ID,
-    zone: ZONE,
     labels: {
       'execution_id' => CLOUDFUNCTIONS_EXECUTION_ID,
-      "#{CLOUDFUNCTIONS_SERVICE_NAME}/function_name" =>
-        CLOUDFUNCTIONS_FUNCTION_NAME,
-      "#{CLOUDFUNCTIONS_SERVICE_NAME}/region" => CLOUDFUNCTIONS_REGION,
       "#{CONTAINER_SERVICE_NAME}/instance_id" => VM_ID,
       "#{CONTAINER_SERVICE_NAME}/cluster_name" => CLOUDFUNCTIONS_CLUSTER_NAME,
-      "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
       "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
-      "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME
+      "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME,
+      "#{COMPUTE_SERVICE_NAME}/zone" => ZONE
     }
   }
 
   CLOUDFUNCTIONS_TEXT_NOT_MATCHED_PARAMS = {
-    service_name: CLOUDFUNCTIONS_SERVICE_NAME,
+    resource: {
+      type: 'cloud_function',
+      labels: {
+        'function_name' => CLOUDFUNCTIONS_FUNCTION_NAME,
+        'region' => CLOUDFUNCTIONS_REGION
+      }
+    },
     log_name: 'cloud-functions',
     project_id: PROJECT_ID,
-    zone: ZONE,
     labels: {
-      "#{CLOUDFUNCTIONS_SERVICE_NAME}/function_name" =>
-        CLOUDFUNCTIONS_FUNCTION_NAME,
-      "#{CLOUDFUNCTIONS_SERVICE_NAME}/region" => CLOUDFUNCTIONS_REGION,
       "#{CONTAINER_SERVICE_NAME}/instance_id" => VM_ID,
       "#{CONTAINER_SERVICE_NAME}/cluster_name" => CLOUDFUNCTIONS_CLUSTER_NAME,
-      "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
       "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,
-      "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME
+      "#{COMPUTE_SERVICE_NAME}/resource_name" => HOSTNAME,
+      "#{COMPUTE_SERVICE_NAME}/zone" => ZONE
     }
   }
 
   CUSTOM_PARAMS = {
-    service_name: COMPUTE_SERVICE_NAME,
+    resource: {
+      type: 'gce_instance',
+      labels: {
+        'instance_id' => CUSTOM_VM_ID,
+        'zone' => CUSTOM_ZONE
+      }
+    },
     log_name: 'test',
     project_id: CUSTOM_PROJECT_ID,
-    zone: CUSTOM_ZONE,
     labels: {
-      "#{COMPUTE_SERVICE_NAME}/resource_type" => 'instance',
-      "#{COMPUTE_SERVICE_NAME}/resource_id" => CUSTOM_VM_ID,
       "#{COMPUTE_SERVICE_NAME}/resource_name" => CUSTOM_HOSTNAME
     }
   }
 
   EC2_PARAMS = {
-    service_name: EC2_SERVICE_NAME,
+    resource: {
+      type: 'aws_ec2_instance',
+      labels: {
+        'instance_id' => EC2_VM_ID,
+        'region' => EC2_PREFIXED_ZONE,
+        'aws_account' => EC2_ACCOUNT_ID
+      }
+    },
     log_name: 'test',
     project_id: EC2_PROJECT_ID,
-    zone: EC2_PREFIXED_ZONE,
     labels: {
-      "#{EC2_SERVICE_NAME}/resource_type" => 'instance',
-      "#{EC2_SERVICE_NAME}/resource_id" => EC2_VM_ID,
-      "#{EC2_SERVICE_NAME}/account_id" => EC2_ACCOUNT_ID,
       "#{EC2_SERVICE_NAME}/resource_name" => HOSTNAME
     }
   }
+
+  # TODO: add tests for dataflow and ml
 
   HTTP_REQUEST_MESSAGE = {
     'requestMethod' => 'POST',
@@ -319,7 +344,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     'remoteIp' => '55.55.55.55',
     'referer' => 'http://referer/',
     'cacheHit' => false,
-    'validatedWithOriginServer' => true
+    'cacheValidatedWithOriginServer' => true
   }
 
   def create_driver(conf = APPLICATION_DEFAULT_CONFIG, tag = 'test')
@@ -448,7 +473,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     setup_container_metadata_stubs
     d = create_driver(NO_DETECT_SUBSERVICE_CONFIG)
     d.run
-    assert_equal COMPUTE_SERVICE_NAME, d.instance.service_name
+    assert_equal COMPUTE_RESOURCE_TYPE, d.instance.resource.type
   end
 
   def test_metadata_overrides_on_gce
@@ -581,11 +606,11 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     d = create_driver
     d.emit('msg' => log_entry(0), 'tag2' => 'test', 'data' => 5000)
     d.run
-    verify_log_entries(1, COMPUTE_PARAMS, 'structPayload') do |entry|
-      assert_equal 3, entry['structPayload'].size, entry
-      assert_equal 'test log entry 0', entry['structPayload']['msg'], entry
-      assert_equal 'test', entry['structPayload']['tag2'], entry
-      assert_equal 5000, entry['structPayload']['data'], entry
+    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      assert_equal 3, entry['jsonPayload'].size, entry
+      assert_equal 'test log entry 0', entry['jsonPayload']['msg'], entry
+      assert_equal 'test', entry['jsonPayload']['tag2'], entry
+      assert_equal 5000, entry['jsonPayload']['data'], entry
     end
   end
 
@@ -620,11 +645,11 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       if log_index == 1
         assert entry.key?('textPayload'), 'Entry did not have textPayload'
       else
-        assert entry.key?('structPayload'), 'Entry did not have structPayload'
-        assert_equal 3, entry['structPayload'].size, entry
-        assert_equal 'test log entry 0', entry['structPayload']['msg'], entry
-        assert_equal 'test', entry['structPayload']['tag2'], entry
-        assert_equal 5000, entry['structPayload']['data'], entry
+        assert entry.key?('jsonPayload'), 'Entry did not have jsonPayload'
+        assert_equal 3, entry['jsonPayload'].size, entry
+        assert_equal 'test log entry 0', entry['jsonPayload']['msg'], entry
+        assert_equal 'test', entry['jsonPayload']['tag2'], entry
+        assert_equal 5000, entry['jsonPayload']['data'], entry
       end
     end
   end
@@ -659,9 +684,9 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     verify_index = 0
     verify_log_entries(emit_index, COMPUTE_PARAMS) do |entry|
       assert_equal expected_ts[verify_index].tv_sec,
-                   entry['metadata']['timestamp']['seconds'], entry
+                   entry['timestamp']['seconds'], entry
       assert_equal expected_ts[verify_index].tv_nsec,
-                   entry['metadata']['timestamp']['nanos'], entry
+                   entry['timestamp']['nanos'], entry
       verify_index += 1
     end
   end
@@ -673,9 +698,9 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     # if timestamp is not a hash it is passed through to the struct payload.
     d.emit('message' => log_entry(0), 'timestamp' => 'not-a-hash')
     d.run
-    verify_log_entries(1, COMPUTE_PARAMS, 'structPayload') do |entry|
-      assert_equal 2, entry['structPayload'].size, entry
-      assert_equal 'not-a-hash', entry['structPayload']['timestamp'], entry
+    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      assert_equal 2, entry['jsonPayload'].size, entry
+      assert_equal 'not-a-hash', entry['jsonPayload']['timestamp'], entry
     end
   end
 
@@ -696,7 +721,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     verify_index = 0
     verify_log_entries(emit_index, COMPUTE_PARAMS) do |entry|
       assert_equal expected_severity[verify_index],
-                   entry['metadata']['severity'], entry
+                   entry['severity'], entry
       verify_index += 1
     end
   end
@@ -777,10 +802,10 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     params[:labels]['sent_label_1'] = 'value1'
     params[:labels]['foo.googleapis.com/bar'] = 'value2'
     params[:labels]['label3'] = 'value3'
-    verify_log_entries(1, params, 'structPayload') do |entry|
-      assert_equal 2, entry['structPayload'].size, entry
-      assert_equal 'test log entry 0', entry['structPayload']['message'], entry
-      assert_equal 'value4', entry['structPayload']['not_a_label'], entry
+    verify_log_entries(1, params, 'jsonPayload') do |entry|
+      assert_equal 2, entry['jsonPayload'].size, entry
+      assert_equal 'test log entry 0', entry['jsonPayload']['message'], entry
+      assert_equal 'value4', entry['jsonPayload']['not_a_label'], entry
     end
   end
 
@@ -814,18 +839,18 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     setup_gce_metadata_stubs
     # The API Client should not retry this and the plugin should consume
     # the exception.
-    stub_request(:post, uri_for_log(COMPUTE_PARAMS))
+    stub_request(:post, WRITE_LOG_ENTRIES_URI)
       .to_return(status: 400, body: 'Bad Request')
     d = create_driver
     d.emit('message' => log_entry(0))
     d.run
-    assert_requested(:post, uri_for_log(COMPUTE_PARAMS), times: 1)
+    assert_requested(:post, WRITE_LOG_ENTRIES_URI, times: 1)
   end
 
   # All credentials errors resolve to a 401.
   def test_client_401
     setup_gce_metadata_stubs
-    stub_request(:post, uri_for_log(COMPUTE_PARAMS))
+    stub_request(:post, WRITE_LOG_ENTRIES_URI)
       .to_return(status: 401, body: 'Unauthorized')
     d = create_driver
     d.emit('message' => log_entry(0))
@@ -834,14 +859,14 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     rescue Google::Apis::AuthorizationError => error
       assert_equal 'Unauthorized', error.message
     end
-    assert_requested(:post, uri_for_log(COMPUTE_PARAMS), times: 2)
+    assert_requested(:post, WRITE_LOG_ENTRIES_URI, times: 2)
   end
 
   def test_server_error
     setup_gce_metadata_stubs
     # The API client should retry this once, then throw an exception which
     # gets propagated through the plugin.
-    stub_request(:post, uri_for_log(COMPUTE_PARAMS))
+    stub_request(:post, WRITE_LOG_ENTRIES_URI)
       .to_return(status: 500, body: 'Server Error')
     d = create_driver
     d.emit('message' => log_entry(0))
@@ -852,7 +877,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       assert_equal 'Server error', error.message
       exception_count += 1
     end
-    assert_requested(:post, uri_for_log(COMPUTE_PARAMS), times: 1)
+    assert_requested(:post, WRITE_LOG_ENTRIES_URI, times: 1)
     assert_equal 1, exception_count
   end
 
@@ -890,11 +915,9 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     d.emit(container_log_entry_with_metadata(log_entry(0)))
     d.run
     verify_log_entries(1, CONTAINER_FROM_METADATA_PARAMS) do |entry|
-      assert_equal CONTAINER_SECONDS_EPOCH, \
-                   entry['metadata']['timestamp']['seconds'], entry
-      assert_equal CONTAINER_NANOS, \
-                   entry['metadata']['timestamp']['nanos'], entry
-      assert_equal CONTAINER_SEVERITY, entry['metadata']['severity'], entry
+      assert_equal CONTAINER_SECONDS_EPOCH, entry['timestamp']['seconds'], entry
+      assert_equal CONTAINER_NANOS, entry['timestamp']['nanos'], entry
+      assert_equal CONTAINER_SEVERITY, entry['severity'], entry
     end
   end
 
@@ -912,10 +935,9 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       d.run
       verify_log_entries(n, CONTAINER_FROM_METADATA_PARAMS) do |entry|
         assert_equal CONTAINER_SECONDS_EPOCH, \
-                     entry['metadata']['timestamp']['seconds'], entry
-        assert_equal CONTAINER_NANOS, \
-                     entry['metadata']['timestamp']['nanos'], entry
-        assert_equal CONTAINER_SEVERITY, entry['metadata']['severity'], entry
+                     entry['timestamp']['seconds'], entry
+        assert_equal CONTAINER_NANOS, entry['timestamp']['nanos'], entry
+        assert_equal CONTAINER_SEVERITY, entry['severity'], entry
       end
     end
   end
@@ -929,10 +951,9 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     d.run
     verify_log_entries(1, CONTAINER_FROM_TAG_PARAMS) do |entry|
       assert_equal CONTAINER_SECONDS_EPOCH, \
-                   entry['metadata']['timestamp']['seconds'], entry
-      assert_equal CONTAINER_NANOS, \
-                   entry['metadata']['timestamp']['nanos'], entry
-      assert_equal CONTAINER_SEVERITY, entry['metadata']['severity'], entry
+                   entry['timestamp']['seconds'], entry
+      assert_equal CONTAINER_NANOS, entry['timestamp']['nanos'], entry
+      assert_equal CONTAINER_SEVERITY, entry['severity'], entry
     end
   end
 
@@ -950,10 +971,9 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       d.run
       verify_log_entries(n, CONTAINER_FROM_TAG_PARAMS) do |entry|
         assert_equal CONTAINER_SECONDS_EPOCH, \
-                     entry['metadata']['timestamp']['seconds'], entry
-        assert_equal CONTAINER_NANOS, \
-                     entry['metadata']['timestamp']['nanos'], entry
-        assert_equal CONTAINER_SEVERITY, entry['metadata']['severity'], entry
+                     entry['timestamp']['seconds'], entry
+        assert_equal CONTAINER_NANOS, entry['timestamp']['nanos'], entry
+        assert_equal CONTAINER_SEVERITY, entry['severity'], entry
       end
     end
   end
@@ -970,10 +990,9 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     ) { |_, oldval, newval| oldval.merge(newval) }
     verify_log_entries(1, expected_params) do |entry|
       assert_equal CONTAINER_SECONDS_EPOCH, \
-                   entry['metadata']['timestamp']['seconds'], entry
-      assert_equal CONTAINER_NANOS, \
-                   entry['metadata']['timestamp']['nanos'], entry
-      assert_equal 'ERROR', entry['metadata']['severity'], entry
+                   entry['timestamp']['seconds'], entry
+      assert_equal CONTAINER_NANOS, entry['timestamp']['nanos'], entry
+      assert_equal 'ERROR', entry['severity'], entry
     end
   end
 
@@ -987,16 +1006,15 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
                                              '"severity": "WARNING"}'))
     d.run
     verify_log_entries(1, CONTAINER_FROM_METADATA_PARAMS,
-                       'structPayload') do |entry|
-      assert_equal 3, entry['structPayload'].size, entry
-      assert_equal 'test log entry 0', entry['structPayload']['msg'], entry
-      assert_equal 'test', entry['structPayload']['tag2'], entry
-      assert_equal 5000, entry['structPayload']['data'], entry
+                       'jsonPayload') do |entry|
+      assert_equal 3, entry['jsonPayload'].size, entry
+      assert_equal 'test log entry 0', entry['jsonPayload']['msg'], entry
+      assert_equal 'test', entry['jsonPayload']['tag2'], entry
+      assert_equal 5000, entry['jsonPayload']['data'], entry
       assert_equal CONTAINER_SECONDS_EPOCH, \
-                   entry['metadata']['timestamp']['seconds'], entry
-      assert_equal CONTAINER_NANOS, \
-                   entry['metadata']['timestamp']['nanos'], entry
-      assert_equal 'WARNING', entry['metadata']['severity'], entry
+                   entry['timestamp']['seconds'], entry
+      assert_equal CONTAINER_NANOS, entry['timestamp']['nanos'], entry
+      assert_equal 'WARNING', entry['severity'], entry
     end
   end
 
@@ -1010,16 +1028,14 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
                                '"severity": "W"}'))
     d.run
     verify_log_entries(1, CONTAINER_FROM_TAG_PARAMS,
-                       'structPayload') do |entry|
-      assert_equal 3, entry['structPayload'].size, entry
-      assert_equal 'test log entry 0', entry['structPayload']['msg'], entry
-      assert_equal 'test', entry['structPayload']['tag2'], entry
-      assert_equal 5000, entry['structPayload']['data'], entry
-      assert_equal CONTAINER_SECONDS_EPOCH, \
-                   entry['metadata']['timestamp']['seconds'], entry
-      assert_equal CONTAINER_NANOS, \
-                   entry['metadata']['timestamp']['nanos'], entry
-      assert_equal 'WARNING', entry['metadata']['severity'], entry
+                       'jsonPayload') do |entry|
+      assert_equal 3, entry['jsonPayload'].size, entry
+      assert_equal 'test log entry 0', entry['jsonPayload']['msg'], entry
+      assert_equal 'test', entry['jsonPayload']['tag2'], entry
+      assert_equal 5000, entry['jsonPayload']['data'], entry
+      assert_equal CONTAINER_SECONDS_EPOCH, entry['timestamp']['seconds'], entry
+      assert_equal CONTAINER_NANOS, entry['timestamp']['nanos'], entry
+      assert_equal 'WARNING', entry['severity'], entry
     end
   end
 
@@ -1031,7 +1047,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     d.emit(cloudfunctions_log_entry(0))
     d.run
     verify_log_entries(1, CLOUDFUNCTIONS_PARAMS) do |entry|
-      assert_equal 'DEBUG', entry['metadata']['severity'], entry
+      assert_equal 'DEBUG', entry['severity'], entry
     end
   end
 
@@ -1048,7 +1064,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       n.times { |i| d.emit(cloudfunctions_log_entry(i)) }
       d.run
       verify_log_entries(n, CLOUDFUNCTIONS_PARAMS) do |entry|
-        assert_equal 'DEBUG', entry['metadata']['severity'], entry
+        assert_equal 'DEBUG', entry['severity'], entry
       end
     end
   end
@@ -1061,7 +1077,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     d.emit(cloudfunctions_log_entry_text_not_matched(0))
     d.run
     verify_log_entries(1, CLOUDFUNCTIONS_TEXT_NOT_MATCHED_PARAMS) do |entry|
-      assert_equal 'INFO', entry['metadata']['severity'], entry
+      assert_equal 'INFO', entry['severity'], entry
     end
   end
 
@@ -1078,7 +1094,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       n.times { |i| d.emit(cloudfunctions_log_entry_text_not_matched(i)) }
       d.run
       verify_log_entries(n, CLOUDFUNCTIONS_TEXT_NOT_MATCHED_PARAMS) do |entry|
-        assert_equal 'INFO', entry['metadata']['severity'], entry
+        assert_equal 'INFO', entry['severity'], entry
       end
     end
   end
@@ -1126,7 +1142,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     d.run
     verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
       assert_equal HTTP_REQUEST_MESSAGE, entry['httpRequest'], entry
-      assert_equal nil, entry['structPayload']['httpRequest'], entry
+      assert_equal nil, entry['jsonPayload']['httpRequest'], entry
     end
   end
 
@@ -1138,7 +1154,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     d.run
     verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
       assert_equal HTTP_REQUEST_MESSAGE, entry['httpRequest'], entry
-      assert_equal 'value', entry['structPayload']['httpRequest']['otherKey'],
+      assert_equal 'value', entry['jsonPayload']['httpRequest']['otherKey'],
                    entry
     end
   end
@@ -1149,8 +1165,8 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     d = create_driver(APPLICATION_DEFAULT_CONFIG)
     d.emit('httpRequest' => 'a_string')
     d.run
-    verify_log_entries(1, COMPUTE_PARAMS, 'structPayload') do |entry|
-      assert_equal 'a_string', entry['structPayload']['httpRequest'], entry
+    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      assert_equal 'a_string', entry['jsonPayload']['httpRequest'], entry
       assert_equal nil, entry['httpRequest'], entry
     end
   end
@@ -1235,11 +1251,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   private
 
-  def uri_for_log(params)
-    'https://logging.googleapis.com/v1beta3/projects/' + params[:project_id] +
-      '/logs/' + params[:log_name] + '/entries:write'
-  end
-
   def stub_metadata_request(metadata_path, response_body)
     stub_request(:get, 'http://169.254.169.254/computeMetadata/v1/' +
                  metadata_path)
@@ -1287,13 +1298,9 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   end
 
   def setup_logging_stubs
-    [COMPUTE_PARAMS, VMENGINE_PARAMS, CONTAINER_FROM_TAG_PARAMS,
-     CONTAINER_FROM_METADATA_PARAMS, CLOUDFUNCTIONS_PARAMS, CUSTOM_PARAMS,
-     EC2_PARAMS].each do |params|
-      stub_request(:post, uri_for_log(params)).to_return do |request|
-        @logs_sent << JSON.parse(request.body)
-        { body: '' }
-      end
+    stub_request(:post, WRITE_LOG_ENTRIES_URI).to_return do |request|
+      @logs_sent << JSON.parse(request.body)
+      { body: '' }
     end
   end
 
@@ -1392,38 +1399,50 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     'test log entry ' + i.to_s
   end
 
-  def check_labels(entry, common_labels, expected_labels)
-    # TODO(salty) test/handle overlap between common_labels and entry labels
-    all_labels ||= common_labels
-    all_labels.merge!(entry['metadata']['labels'] || {})
-    all_labels.each do |key, value|
+  def check_labels(labels, expected_labels)
+    labels.each do |key, value|
       assert value.is_a?(String), "Value #{value} for label #{key} " \
         'is not a string: ' + value.class.name
       assert expected_labels.key?(key), "Unexpected label #{key} => #{value}"
       assert_equal expected_labels[key], value, 'Value mismatch - expected ' \
         "#{expected_labels[key]} in #{key} => #{value}"
     end
-    assert_equal expected_labels.length, all_labels.length, 'Expected ' \
-      "#{expected_labels.length} labels, got #{all_labels.length}"
+    assert_equal expected_labels.length, labels.length, 'Expected ' \
+      "#{expected_labels.length} labels: #{expected_labels}, got " \
+      "#{labels.length} labels: #{labels}"
   end
 
   # The caller can optionally provide a block which is called for each entry.
   def verify_log_entries(n, params, payload_type = 'textPayload')
     i = 0
-    @logs_sent.each do |batch|
-      batch['entries'].each do |entry|
+    @logs_sent.each do |request|
+      request['entries'].each do |entry|
         unless payload_type.empty?
           assert entry.key?(payload_type), 'Entry did not contain expected ' \
             "#{payload_type} key: " + entry.to_s
           # Check the payload for textPayload, otherwise it's up to the caller.
           if payload_type == 'textPayload'
-            assert_equal "test log entry #{i}", entry['textPayload'], batch
+            assert_equal "test log entry #{i}", entry['textPayload'], request
           end
         end
 
-        assert_equal params[:zone], entry['metadata']['zone']
-        assert_equal params[:service_name], entry['metadata']['serviceName']
-        check_labels entry, batch['commonLabels'], params[:labels]
+        # per-entry resource or log_name overrides the corresponding field
+        # from the request.  Labels are merged, with the per-entry label
+        # taking precedence in case of overlap.
+        resource = \
+          entry.key?('resource') ? entry['resource'] : request['resource']
+        log_name = \
+          entry.key?('logName') ? entry['logName'] : request['logName']
+        # TODO: test/handle overlap between common_labels and entry labels?
+        labels ||= request['labels']
+        labels.merge!(entry['labels'] || {})
+
+        assert_equal \
+          "projects/#{params[:project_id]}/logs/#{params[:log_name]}",
+          log_name
+        assert_equal params[:resource][:type], resource['type']
+        check_labels resource['labels'], params[:resource][:labels]
+        check_labels labels, params[:labels]
         yield(entry) if block_given?
         i += 1
         assert i <= n, "Number of entries #{i} exceeds expected number #{n}"

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -43,13 +43,21 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   HOSTNAME = Socket.gethostname
   WRITE_LOG_ENTRIES_URI = 'https://logging.googleapis.com/v2beta1/entries:write'
 
-  COMPUTE_SERVICE_NAME = 'compute.googleapis.com'
   APPENGINE_SERVICE_NAME = 'appengine.googleapis.com'
+  COMPUTE_SERVICE_NAME = 'compute.googleapis.com'
   CONTAINER_SERVICE_NAME = 'container.googleapis.com'
   CLOUDFUNCTIONS_SERVICE_NAME = 'cloudfunctions.googleapis.com'
-  EC2_SERVICE_NAME = 'ec2.amazonaws.com'
   DATAFLOW_SERVICE_NAME = 'dataflow.googleapis.com'
+  EC2_SERVICE_NAME = 'ec2.amazonaws.com'
   ML_SERVICE_NAME = 'ml.googleapis.com'
+
+  APPENGINE_RESOURCE_TYPE = 'gae_app'
+  CLOUDFUNCTIONS_RESOURCE_TYPE = 'cloud_function'
+  COMPUTE_RESOURCE_TYPE = 'gce_instance'
+  CONTAINER_RESOURCE_TYPE = 'container'
+  DATAFLOW_RESOURCE_TYPE = 'dataflow_step'
+  EC2_RESOURCE_TYPE = 'aws_ec2_instance'
+  ML_RESOURCE_TYPE = 'ml_job'
 
   # attributes used for the GCE metadata service
   PROJECT_ID = 'test-project-id'
@@ -216,7 +224,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   # Service configurations for various services
   COMPUTE_PARAMS = {
     resource: {
-      type: 'gce_instance',
+      type: COMPUTE_RESOURCE_TYPE,
       labels: {
         'instance_id' => VM_ID,
         'zone' => ZONE
@@ -231,7 +239,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   VMENGINE_PARAMS = {
     resource: {
-      type: 'gae_app',
+      type: APPENGINE_RESOURCE_TYPE,
       labels: {
         'module_id' => MANAGED_VM_BACKEND_NAME,
         'version_id' => MANAGED_VM_BACKEND_VERSION
@@ -251,7 +259,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   CONTAINER_FROM_METADATA_PARAMS = {
     resource: {
-      type: 'container',
+      type: CONTAINER_RESOURCE_TYPE,
       labels: {
         'cluster_name' => CONTAINER_CLUSTER_NAME,
         'namespace_id' => CONTAINER_NAMESPACE_ID,
@@ -275,7 +283,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   # Almost the same as from metadata, but missing namespace_id and pod_id.
   CONTAINER_FROM_TAG_PARAMS = {
     resource: {
-      type: 'container',
+      type: CONTAINER_RESOURCE_TYPE,
       labels: {
         'cluster_name' => CONTAINER_CLUSTER_NAME,
         'instance_id' => VM_ID,
@@ -299,7 +307,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   CLOUDFUNCTIONS_PARAMS = {
     resource: {
-      type: 'cloud_function',
+      type: CLOUDFUNCTIONS_RESOURCE_TYPE,
       labels: {
         'function_name' => CLOUDFUNCTIONS_FUNCTION_NAME,
         'region' => CLOUDFUNCTIONS_REGION
@@ -319,7 +327,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   CLOUDFUNCTIONS_TEXT_NOT_MATCHED_PARAMS = {
     resource: {
-      type: 'cloud_function',
+      type: CLOUDFUNCTIONS_RESOURCE_TYPE,
       labels: {
         'function_name' => CLOUDFUNCTIONS_FUNCTION_NAME,
         'region' => CLOUDFUNCTIONS_REGION
@@ -338,7 +346,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   DATAFLOW_PARAMS = {
     resource: {
-      type: 'dataflow_step',
+      type: DATAFLOW_RESOURCE_TYPE,
       labels: {
         'job_name' => DATAFLOW_JOB_NAME,
         'job_id' => DATAFLOW_JOB_ID,
@@ -357,7 +365,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   ML_PARAMS = {
     resource: {
-      type: 'ml_job',
+      type: ML_RESOURCE_TYPE,
       labels: {
         'job_id' => ML_JOB_ID,
         'task_name' => ML_TASK_NAME
@@ -376,7 +384,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   CUSTOM_PARAMS = {
     resource: {
-      type: 'gce_instance',
+      type: COMPUTE_RESOURCE_TYPE,
       labels: {
         'instance_id' => CUSTOM_VM_ID,
         'zone' => CUSTOM_ZONE
@@ -391,7 +399,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   EC2_PARAMS = {
     resource: {
-      type: 'aws_ec2_instance',
+      type: EC2_RESOURCE_TYPE,
       labels: {
         'instance_id' => EC2_VM_ID,
         'region' => EC2_PREFIXED_ZONE,
@@ -539,12 +547,12 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def test_gce_used_when_detect_subservice_is_false
     setup_gce_metadata_stubs
-    # This would cause the service to be container.googleapis.com if not for the
-    # detect_subservice=false config.
+    # This would cause the resource type to be CONTAINER_RESOURCE_TYPE if not
+    # for the detect_subservice=false config.
     setup_container_metadata_stubs
     d = create_driver(NO_DETECT_SUBSERVICE_CONFIG)
     d.run
-    assert_equal 'gce_instance', d.instance.resource.type
+    assert_equal COMPUTE_RESOURCE_TYPE, d.instance.resource.type
   end
 
   def test_metadata_overrides_on_gce


### PR DESCRIPTION
* Migrate to Logging API v2beta1
  * MonitoredResource now specifies the service and keys, rather than using labels
  * Update all "hardcoded" services to use the new schema
  * Add some special-case code for Dataflow and ML which use labels/label_map config
  * Update tests; add tests for dataflow and ML