### PR TITLE
Escape the slash used for the appengine log prefix.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -887,7 +887,7 @@ module Fluent
         return 'cloud-functions'
       elsif @running_on_managed_vm
         # Add a prefix to Managed VM logs to prevent namespace collisions.
-        return "#{APPENGINE_SERVICE}/#{tag}"
+        return "#{APPENGINE_SERVICE}%2F#{tag}"
       elsif resource.type == CONTAINER_RESOURCE_TYPE
         # For Kubernetes logs, use just the container name as the log name
         # if we have it.

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -245,7 +245,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
         'version_id' => MANAGED_VM_BACKEND_VERSION
       }
     },
-    log_name: "#{APPENGINE_SERVICE_NAME}/test",
+    log_name: "#{APPENGINE_SERVICE_NAME}%2Ftest",
     project_id: PROJECT_ID,
     labels: {
       "#{COMPUTE_SERVICE_NAME}/resource_id" => VM_ID,


### PR DESCRIPTION
In v1 this happened automatically; in v2 we have to do it ourselves,
or the API will reject it.

I should have been more wary when I had to change the test.