### PR TITLE
Update Fluentd version to latest

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -19,7 +19,7 @@ eos
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'fluentd', '~> 0.10', '<= 0.13'
+  gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'google-api-client', '> 0.9'
   gem.add_runtime_dependency 'googleauth', '~> 0.4'
   gem.add_runtime_dependency 'json', '~> 1.8'

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -324,7 +324,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   def create_driver(conf = APPLICATION_DEFAULT_CONFIG, tag = 'test')
     Fluent::Test::BufferedOutputTestDriver.new(
-      Fluent::GoogleCloudOutput, tag).configure(conf, use_v1_config: true)
+      Fluent::GoogleCloudOutput, tag).configure(conf, true)
   end
 
   def test_configure_service_account_application_default
@@ -638,9 +638,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     [Time.at(123_456.789), Time.at(0), Time.now].each do |ts|
       # Test the "native" fluentd timestamp as well as our nanosecond tags.
       d.emit({ 'message' => log_entry(emit_index) }, ts.to_f)
-      # The native timestamp currently only supports second granularity
-      # (fluentd issue #461), so strip nanoseconds from the expected value.
-      expected_ts.push(Time.at(ts.tv_sec))
+      expected_ts.push(ts)
       emit_index += 1
       d.emit('message' => log_entry(emit_index),
              'timeNanos' => ts.tv_sec * 1_000_000_000 + ts.tv_nsec)
@@ -660,8 +658,13 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     verify_log_entries(emit_index, COMPUTE_PARAMS) do |entry|
       assert_equal expected_ts[verify_index].tv_sec,
                    entry['metadata']['timestamp']['seconds'], entry
-      assert_equal expected_ts[verify_index].tv_nsec,
-                   entry['metadata']['timestamp']['nanos'], entry
+      # Fluentd v0.14 onwards supports nanosecond timestamp values.
+      # Added in 600 ns delta to avoid flaky tests introduced
+      # due to rounding error in double-precision floating-point numbers
+      # (to account for the missing 9 bits of precision ~ 512 ns).
+      # See http://wikipedia.org/wiki/Double-precision_floating-point_format
+      assert_in_delta expected_ts[verify_index].tv_nsec,
+                      entry['metadata']['timestamp']['nanos'], 600, entry
       verify_index += 1
     end
   end


### PR DESCRIPTION
Removed Fluentd version pin. Fixed test which now supports nanosecond timestamp log message verification. Updated function call to remove variable name declaration for use_v1_config (no longer seems to be supported). This is effectively a revert of #73.