### PR TITLE
Add test cases for malformated json key handling.

### DIFF
--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -551,8 +551,10 @@ module BaseTest
       d = create_driver
       d.emit(
         'int_key' => { 1 => message },
-        'array_key' => { [1, 2, 3, 4] => message },
+        'int_array_key' => { [1, 2, 3, 4] => message },
+        'string_array_key' => { %w(a b c) => message },
         'hash_key' => { { 'some_key' => 'some_value' } => message },
+        'mixed_key' => { { 'some_key' => %w(a b c) } => message },
         'symbol_key' => { some_symbol: message },
         'nil_key' => { nil => message }
       )
@@ -560,13 +562,17 @@ module BaseTest
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'structPayload') do |entry|
       fields = get_fields(entry['structPayload'])
-      assert_equal 5, fields.size, entry
+      assert_equal 7, fields.size, entry
       assert_equal message, get_string(get_fields(get_struct(fields \
                    ['int_key']))['1']), entry
       assert_equal message, get_string(get_fields(get_struct(fields \
-                   ['array_key']))['[1, 2, 3, 4]']), entry
+                   ['int_array_key']))['[1, 2, 3, 4]']), entry
+      assert_equal message, get_string(get_fields(get_struct(fields \
+                   ['string_array_key']))['["a", "b", "c"]']), entry
       assert_equal message, get_string(get_fields(get_struct(fields \
                    ['hash_key']))['{"some_key"=>"some_value"}']), entry
+      assert_equal message, get_string(get_fields(get_struct(fields \
+                   ['mixed_key']))['{"some_key"=>["a", "b", "c"]}']), entry
       assert_equal message, get_string(get_fields(get_struct(fields \
                    ['symbol_key']))['some_symbol']), entry
       assert_equal message, get_string(get_fields(get_struct(fields \


### PR DESCRIPTION
Verified that we are not doing any special json parsing when converting malformatted hash key to string in the REST path (Otherwise the key would show up as `['[1,2,3,4]']` instead of `['[1, 2, 3, 4]']`).

Added some test cases.