### PR TITLE
Pin gRPC gem version to 1.0.1 until the GRPC::Cancelled bug is fixed.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -23,7 +23,7 @@ eos
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
   gem.add_runtime_dependency 'google-api-client', '> 0.9'
   gem.add_runtime_dependency 'googleauth', '~> 0.4'
-  gem.add_runtime_dependency 'grpc', '~> 1.0'
+  gem.add_runtime_dependency 'grpc', '= 1.0.1'
   gem.add_runtime_dependency 'json', '~> 1.8'
 
   gem.add_development_dependency 'mocha', '~> 1.1'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -23,7 +23,7 @@ eos
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
   gem.add_runtime_dependency 'google-api-client', '> 0.9'
   gem.add_runtime_dependency 'googleauth', '~> 0.4'
-  gem.add_runtime_dependency 'grpc', '~> 1.0', '< 1.0.2'
+  gem.add_runtime_dependency 'grpc', '~> 1.0', '< 1.1.0'
   gem.add_runtime_dependency 'json', '~> 1.8'
 
   gem.add_development_dependency 'mocha', '~> 1.1'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -23,7 +23,7 @@ eos
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
   gem.add_runtime_dependency 'google-api-client', '> 0.9'
   gem.add_runtime_dependency 'googleauth', '~> 0.4'
-  gem.add_runtime_dependency 'grpc', '= 1.0.1'
+  gem.add_runtime_dependency 'grpc', '~> 1.0', '< 1.0.2'
   gem.add_runtime_dependency 'json', '~> 1.8'
 
   gem.add_development_dependency 'mocha', '~> 1.1'


### PR DESCRIPTION
The latest grpc gem broke one of our tests related to `GRPC::Cancelled`. Seems the default error message ("unknown cause") is returned instead of ("Cancelled"). To unblock us from releasing our gem, we decided to pin the grpc version to `1.0.1` before a fix in grpc is placed.

```
1.1.2 - February 10, 2017 x64-mingw32 (2.85 MB)
1.1.2 - February 10, 2017 x86_64-linux (7.41 MB)
1.1.2 - February 10, 2017 universal-darwin (4.18 MB)
1.1.2 - February 10, 2017 x86-mingw32 (2.85 MB)
1.1.2 - February 10, 2017 (2.3 MB)
1.0.1 - October 27, 2016 universal-darwin (3.16 MB)
1.0.1 - October 27, 2016 x64-mingw32 (2.57 MB)
1.0.1 - October 27, 2016 x86-mingw32 (2.57 MB)
1.0.1 - October 27, 2016 x86_64-linux (6.11 MB)
1.0.1 - October 27, 2016 x86-linux (5.58 MB)
```