### PR TITLE
When constructing a monitored resource, translate namespace_name and pod_name to namespace_id and pod_id, respectively.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -450,12 +450,9 @@ module Fluent
         # Do this here to avoid having to repeat it for each record.
         match_data = @compiled_kubernetes_tag_regexp.match(tag)
         if match_data
-          group_resource.labels['container_name'] =
-            match_data['container_name']
-          %w(namespace_name pod_name).each do |field|
-            group_common_labels["#{CONTAINER_CONSTANTS[:service]}/#{field}"] =
-              match_data[field]
-          end
+          group_resource.labels['container_name'] = match_data['container_name']
+          group_resource.labels['namespace_id'] = match_data['namespace_name']
+          group_resource.labels['pod_id'] = match_data['pod_name']
         end
       end
 

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -453,6 +453,10 @@ module Fluent
           group_resource.labels['container_name'] = match_data['container_name']
           group_resource.labels['namespace_id'] = match_data['namespace_name']
           group_resource.labels['pod_id'] = match_data['pod_name']
+          %w(namespace_name pod_name).each do |field|
+            group_common_labels["#{CONTAINER_CONSTANTS[:service]}/#{field}"] =
+              match_data[field]
+          end
         end
       end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -270,13 +270,16 @@ module BaseTest
     }
   }
 
-  # Almost the same as from metadata, but missing namespace_id and pod_id.
+  # Almost the same as from metadata, but namespace_id and pod_id come from
+  # namespace and pod names.
   CONTAINER_FROM_TAG_PARAMS = {
     resource: {
       type: CONTAINER_CONSTANTS[:resource_type],
       labels: {
         'cluster_name' => CONTAINER_CLUSTER_NAME,
+        'namespace_id' => CONTAINER_NAMESPACE_NAME,
         'instance_id' => VM_ID,
+        'pod_id' => CONTAINER_POD_NAME,
         'container_name' => CONTAINER_CONTAINER_NAME,
         'zone' => ZONE
       }
@@ -284,9 +287,6 @@ module BaseTest
     log_name: CONTAINER_CONTAINER_NAME,
     project_id: PROJECT_ID,
     labels: {
-      "#{CONTAINER_CONSTANTS[:service]}/namespace_name" =>
-        CONTAINER_NAMESPACE_NAME,
-      "#{CONTAINER_CONSTANTS[:service]}/pod_name" => CONTAINER_POD_NAME,
       "#{CONTAINER_CONSTANTS[:service]}/stream" => CONTAINER_STREAM,
       "#{COMPUTE_CONSTANTS[:service]}/resource_name" => HOSTNAME
     }

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -287,6 +287,9 @@ module BaseTest
     log_name: CONTAINER_CONTAINER_NAME,
     project_id: PROJECT_ID,
     labels: {
+      "#{CONTAINER_CONSTANTS[:service]}/namespace_name" =>
+        CONTAINER_NAMESPACE_NAME,
+      "#{CONTAINER_CONSTANTS[:service]}/pod_name" => CONTAINER_POD_NAME,
       "#{CONTAINER_CONSTANTS[:service]}/stream" => CONTAINER_STREAM,
       "#{COMPUTE_CONSTANTS[:service]}/resource_name" => HOSTNAME
     }


### PR DESCRIPTION
@crassirostris @summit FYI.