### PR TITLE
Add Google Cloud Dataproc support.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -318,14 +318,6 @@ module Fluent
             @resource.type = DATAFLOW_CONSTANTS[:resource_type]
           elsif @subservice_name == ML_CONSTANTS[:service]
             @resource.type = ML_CONSTANTS[:resource_type]
-          elsif @subservice_name = DATAPROC_CONSTANTS[:service]
-            @resource.type = DATAPROC_CONSTANTS[:resource_type]
-            @resource.labels['cluster_uuid'] =
-              fetch_gce_metadata('instance/attributes/dataproc-cluster-uuid')
-            @resource.labels['cluster_name'] =
-              fetch_gce_metadata('instance/attributes/dataproc-cluster-name')
-            @resource.labels['region'] =
-              fetch_gce_metadata('instance/attributes/dataproc-region')
           end
         elsif @detect_subservice
           # Check for specialized GCE environments.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -58,6 +58,10 @@ module Fluent
         service: 'dataflow.googleapis.com',
         resource_type: 'dataflow_step'
       }
+      DATAPROC_CONSTANTS = {
+        service: 'cluster.dataproc.googleapis.com',
+        resource_type: 'cloud_dataproc_cluster'
+      }
       EC2_CONSTANTS = {
         service: 'ec2.amazonaws.com',
         resource_type: 'aws_ec2_instance'
@@ -314,6 +318,14 @@ module Fluent
             @resource.type = DATAFLOW_CONSTANTS[:resource_type]
           elsif @subservice_name == ML_CONSTANTS[:service]
             @resource.type = ML_CONSTANTS[:resource_type]
+          elsif @subservice_name = DATAPROC_CONSTANTS[:service]
+            @resource.type = DATAPROC_CONSTANTS[:resource_type]
+            @resource.labels['cluster_uuid'] =
+              fetch_gce_metadata('instance/attributes/dataproc-cluster-uuid')
+            @resource.labels['cluster_name'] =
+              fetch_gce_metadata('instance/attributes/dataproc-cluster-name')
+            @resource.labels['region'] =
+              fetch_gce_metadata('instance/attributes/dataproc-region')
           end
         elsif @detect_subservice
           # Check for specialized GCE environments.
@@ -339,6 +351,16 @@ module Fluent
             @resource.labels['cluster_name'] =
               cluster_name_from_kube_env(@kube_env)
             detect_cloudfunctions(attributes)
+          elsif attributes.include?('dataproc-cluster-uuid') &&
+                attributes.include?('dataproc-cluster-name')
+            # Dataproc
+            @resource.type = DATAPROC_CONSTANTS[:resource_type]
+            @resource.labels['cluster_uuid'] =
+              fetch_gce_metadata('instance/attributes/dataproc-cluster-uuid')
+            @resource.labels['cluster_name'] =
+              fetch_gce_metadata('instance/attributes/dataproc-cluster-name')
+            @resource.labels['region'] =
+              fetch_gce_metadata('instance/attributes/dataproc-region')
           end
         end
         # Some services have the GCE instance_id and zone as MonitoredResource

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -903,6 +903,17 @@ module BaseTest
     end
   end
 
+  def test_dataproc_log
+    setup_gce_metadata_stubs
+    setup_dataproc_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit(dataproc_log_entry('test message'))
+      d.run
+    end
+    verify_log_entries(1, DATAPROC_PARAMS, 'jsonPayload')
+  end
+
   def test_http_request_from_record
     setup_gce_metadata_stubs
     setup_logging_stubs do
@@ -1001,17 +1012,6 @@ module BaseTest
         assert_nil get_fields(entry['jsonPayload'])['httpRequest'], entry
       end
     end
-  end
-
-  def test_dataproc_log
-    setup_gce_metadata_stubs
-    setup_dataproc_metadata_stubs
-    setup_logging_stubs do
-      d = create_driver
-      d.emit(dataproc_log_entry('test message'))
-      d.run
-    end
-    verify_log_entries(1, DATAPROC_PARAMS, 'jsonPayload')
   end
 
   private

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1118,10 +1118,11 @@ module BaseTest
       'instance/attributes/',
       "attribute1\ndataproc-cluster-uuid\ndataproc-cluster-name")
     stub_metadata_request('instance/attributes/dataproc-cluster-name',
-                          'test-cluster')
+                          DATAPROC_CLUSTER_NAME)
     stub_metadata_request('instance/attributes/dataproc-cluster-uuid',
-                          '00000000-0000-0000-0000-000000000000')
-    stub_metadata_request('instance/attributes/dataproc-region', 'unittest')
+                          DATAPROC_CLUSTER_UUID)
+    stub_metadata_request('instance/attributes/dataproc-region',
+                          DATAPROC_REGION)
   end
 
   def container_tag_with_container_name(container_name)

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1008,10 +1008,10 @@ module BaseTest
     setup_dataproc_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit(dataproc_log_entry("test message"))
+      d.emit(dataproc_log_entry('test message'))
       d.run
     end
-    verify_log_entries(1, DATAPROC_PARAMS, "jsonPayload")
+    verify_log_entries(1, DATAPROC_PARAMS, 'jsonPayload')
   end
 
   private
@@ -1117,8 +1117,10 @@ module BaseTest
     stub_metadata_request(
       'instance/attributes/',
       "attribute1\ndataproc-cluster-uuid\ndataproc-cluster-name")
-    stub_metadata_request('instance/attributes/dataproc-cluster-name', 'test-cluster')
-    stub_metadata_request('instance/attributes/dataproc-cluster-uuid', '00000000-0000-0000-0000-000000000000')
+    stub_metadata_request('instance/attributes/dataproc-cluster-name',
+                          'test-cluster')
+    stub_metadata_request('instance/attributes/dataproc-cluster-uuid',
+                          '00000000-0000-0000-0000-000000000000')
     stub_metadata_request('instance/attributes/dataproc-region', 'unittest')
   end
 
@@ -1175,11 +1177,12 @@ module BaseTest
     }
   end
 
-  def dataproc_log_entry(message, source_class = "com.example.Example", filename = "test.log")
+  def dataproc_log_entry(message, source_class = 'com.example.Example',
+                         filename = 'test.log')
     {
       filename: filename,
       class: source_class,
-      message: log_entry(message),
+      message: log_entry(message)
     }
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1003,6 +1003,17 @@ module BaseTest
     end
   end
 
+  def test_dataproc_log
+    setup_gce_metadata_stubs
+    setup_dataproc_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit(dataproc_log_entry("test message"))
+      d.run
+    end
+    verify_log_entries(1, DATAPROC_PARAMS, "jsonPayload")
+  end
+
   private
 
   def stub_metadata_request(metadata_path, response_body)
@@ -1102,6 +1113,15 @@ module BaseTest
                           CLOUDFUNCTIONS_REGION)
   end
 
+  def setup_dataproc_metadata_stubs
+    stub_metadata_request(
+      'instance/attributes/',
+      "attribute1\ndataproc-cluster-uuid\ndataproc-cluster-name")
+    stub_metadata_request('instance/attributes/dataproc-cluster-name', 'test-cluster')
+    stub_metadata_request('instance/attributes/dataproc-cluster-uuid', '00000000-0000-0000-0000-000000000000')
+    stub_metadata_request('instance/attributes/dataproc-region', 'unittest')
+  end
+
   def container_tag_with_container_name(container_name)
     "kubernetes.#{CONTAINER_POD_NAME}_#{CONTAINER_NAMESPACE_NAME}_" \
       "#{container_name}"
@@ -1152,6 +1172,14 @@ module BaseTest
     {
       step: DATAFLOW_STEP_ID,
       message: log_entry(i)
+    }
+  end
+
+  def dataproc_log_entry(message, source_class = "com.example.Example", filename = "test.log")
+    {
+      filename: filename,
+      class: source_class,
+      message: log_entry(message),
     }
   end
 

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -84,8 +84,8 @@ module Constants
   DATAFLOW_TAG = 'dataflow.googleapis.com/worker'
 
   # Dataproc specific labels.
-  DATAPROC_CLUSTER_NAME = "test-cluster"
-  DATAPROC_CLUSTER_UUID = "00000000-0000-0000-0000-000000000000"
+  DATAPROC_CLUSTER_NAME = 'test-cluster'
+  DATAPROC_CLUSTER_UUID = '00000000-0000-0000-0000-000000000000'
   DATAPROC_REGION = 'unittest'
 
   # ML specific labels.
@@ -345,8 +345,8 @@ module Constants
       type: DATAPROC_CONSTANTS[:resource_type],
       labels: {
         'cluster_name' => DATAPROC_CLUSTER_NAME,
-        "cluster_uuid" => DATAPROC_CLUSTER_UUID,
-        'region' => DATAPROC_REGION,
+        'cluster_uuid' => DATAPROC_CLUSTER_UUID,
+        'region' => DATAPROC_REGION
       }
     },
     log_name: 'test',
@@ -354,7 +354,7 @@ module Constants
     labels: {
       "#{COMPUTE_CONSTANTS[:service]}/resource_name" => HOSTNAME,
       "#{COMPUTE_CONSTANTS[:service]}/resource_id" => VM_ID,
-      "#{COMPUTE_CONSTANTS[:service]}/zone" => ZONE,
+      "#{COMPUTE_CONSTANTS[:service]}/zone" => ZONE
     }
   }
 

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -83,6 +83,11 @@ module Constants
   DATAFLOW_STEP_ID = 'step_1'
   DATAFLOW_TAG = 'dataflow.googleapis.com/worker'
 
+  # Dataproc specific labels.
+  DATAPROC_CLUSTER_NAME = "test-cluster"
+  DATAPROC_CLUSTER_UUID = "00000000-0000-0000-0000-000000000000"
+  DATAPROC_REGION = 'unittest'
+
   # ML specific labels.
   ML_REGION = 'us-central1'
   ML_JOB_ID = 'job_name_1'
@@ -332,6 +337,24 @@ module Constants
       "#{COMPUTE_CONSTANTS[:service]}/resource_id" => VM_ID,
       "#{COMPUTE_CONSTANTS[:service]}/resource_name" => HOSTNAME,
       "#{COMPUTE_CONSTANTS[:service]}/zone" => ZONE
+    }
+  }
+
+  DATAPROC_PARAMS = {
+    resource: {
+      type: DATAPROC_CONSTANTS[:resource_type],
+      labels: {
+        'cluster_name' => DATAPROC_CLUSTER_NAME,
+        "cluster_uuid" => DATAPROC_CLUSTER_UUID,
+        'region' => DATAPROC_REGION,
+      }
+    },
+    log_name: 'test',
+    project_id: PROJECT_ID,
+    labels: {
+      "#{COMPUTE_CONSTANTS[:service]}/resource_name" => HOSTNAME,
+      "#{COMPUTE_CONSTANTS[:service]}/resource_id" => VM_ID,
+      "#{COMPUTE_CONSTANTS[:service]}/zone" => ZONE,
     }
   }
 


### PR DESCRIPTION
Adding Cloud Dataproc support directly to plugin (currently Cloud Dataproc image uses a forked version of the plugin).