### PR TITLE
Add optional prometheus monitoring

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -32,4 +32,5 @@ eos
   gem.add_development_dependency 'rubocop', '~> 0.35.0'
   gem.add_development_dependency 'webmock', '~> 1.17'
   gem.add_development_dependency 'test-unit', '~> 3.0'
+  gem.add_development_dependency 'prometheus-client', '~> 0.7.1'
 end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -16,6 +16,7 @@ require 'google/apis'
 require 'helper'
 require 'mocha/test_unit'
 require 'webmock/test_unit'
+require 'prometheus/client'
 
 require_relative 'constants'
 
@@ -1125,6 +1126,10 @@ module BaseTest
                           DATAPROC_REGION)
   end
 
+  def setup_prometheus
+    Prometheus::Client.registry.instance_variable_set('@metrics', {})
+  end
+
   def container_tag_with_container_name(container_name)
     "kubernetes.#{CONTAINER_POD_NAME}_#{CONTAINER_NAMESPACE_NAME}_" \
       "#{container_name}"
@@ -1306,6 +1311,11 @@ module BaseTest
   # a plain equal. e.g. assert_in_delta.
   def assert_equal_with_default(_field, _expected_value, _default_value, _entry)
     _undefined
+  end
+
+  def assert_prometheus_metric_value(_metric_name, _expected_value, _labels)
+    metric = Prometheus::Client.registry.get(_metric_name)
+    assert_equal(_expected_value, metric.get(_labels))
   end
 
   # Get the fields of the payload.

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -140,6 +140,10 @@ module Constants
     detect_subservice false
   )
 
+  PROMETHEUS_ENABLE_CONFIG = %(
+    prometheus_monitoring_enabled true
+  )
+
   CUSTOM_METADATA_CONFIG = %(
     project_id #{CUSTOM_PROJECT_ID}
     zone #{CUSTOM_ZONE}

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -70,6 +70,76 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     assert_equal 1, exception_count
   end
 
+  def test_prometheus_successful_call
+    setup_gce_metadata_stubs
+    setup_prometheus
+    stub_request(:post, WRITE_LOG_ENTRIES_URI)
+      .to_return(status: 200, body: 'OK')
+    d = create_driver(PROMETHEUS_ENABLE_CONFIG)
+    d.emit('message' => log_entry(0))
+    d.run
+    assert_prometheus_metric_value(:stackdriver_http_requests_count, 1, { grpc: false, code: 200 })
+  end
+
+  def test_prometheus_failed_call
+    setup_gce_metadata_stubs
+    setup_prometheus
+    stub_request(:post, WRITE_LOG_ENTRIES_URI)
+      .to_return(status: 401, body: 'Unauthorized')
+    d = create_driver(PROMETHEUS_ENABLE_CONFIG)
+    d.emit('message' => log_entry(0))
+    begin
+      d.run
+    rescue Google::Apis::AuthorizationError => error
+      assert_equal 'Unauthorized', error.message
+    end
+    assert_prometheus_metric_value(:stackdriver_http_requests_count, 1, { grpc: false, code: 401 })
+  end
+
+  def test_prometheus_successfully_ingested_entries
+    setup_gce_metadata_stubs
+    setup_prometheus
+    stub_request(:post, WRITE_LOG_ENTRIES_URI)
+      .to_return(status: 200, body: 'OK')
+    d = create_driver(PROMETHEUS_ENABLE_CONFIG)
+    d.emit('message' => log_entry(0))
+    d.run
+    assert_prometheus_metric_value(:stackdriver_log_entries_count, 1, { success: true })
+    assert_prometheus_metric_value(:stackdriver_log_entries_count, 0, { success: false })
+  end
+
+  def test_prometheus_dropped_entries
+    setup_gce_metadata_stubs
+    setup_prometheus
+    stub_request(:post, WRITE_LOG_ENTRIES_URI)
+      .to_return(status: 401, body: 'Unauthorized')
+    d = create_driver(PROMETHEUS_ENABLE_CONFIG)
+    d.emit('message' => log_entry(0))
+    begin
+      d.run
+    rescue Google::Apis::AuthorizationError => error
+      assert_equal 'Unauthorized', error.message
+    end
+    assert_prometheus_metric_value(:stackdriver_log_entries_count, 0, { success: true })
+    assert_prometheus_metric_value(:stackdriver_log_entries_count, 1, { success: false })
+  end
+
+  def test_prometheus_retry_without_ingesting
+    setup_gce_metadata_stubs
+    setup_prometheus
+    stub_request(:post, WRITE_LOG_ENTRIES_URI)
+      .to_return(status: 500, body: 'Server Error')
+    d = create_driver(PROMETHEUS_ENABLE_CONFIG)
+    d.emit('message' => log_entry(0))
+    begin
+      d.run
+    rescue Google::Apis::ServerError => error
+      assert_equal 'Server error', error.message
+    end
+    assert_prometheus_metric_value(:stackdriver_log_entries_count, 0, { success: true })
+    assert_prometheus_metric_value(:stackdriver_log_entries_count, 0, { success: false })
+  end
+
   # This test looks similar between the grpc and non-grpc paths except that when
   # parsing "105", the grpc path responds with "DEBUG", while the non-grpc path
   # responds with "100".


### PR DESCRIPTION
Add an option to the plugin which, when enabled, registers and propagates metrics in the default Prometheus registry to be later picked up and exposed on some endpoint by e.g. https://github.com/kazegusuri/fluent-plugin-prometheus. Prometheus-specific part is abstracted away from the working code to be easily extended to facilitate others monitoring solutions.

/cc @igorpeshansky @qingling128 @piosz @fgrzadkowski