### PR TITLE
Add docs for set project_id in conf

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -37,6 +37,13 @@ No further configuration is required. The plugin uses
 for authorization - for additional information see 
 {here}[https://cloud.google.com/logging/docs/agent/authorization].
 
+If your GCE and Logging service are in different project, you can specify the project id in your fluentd configuration by `project_id` parameter like this:
+
+    <match **>
+      type google_cloud
+      project_id YOUR_PROJECT_ID
+    </match>
+
 <em>The previously documented parameters auth_method, private_key_email,
 and private_key_path are removed, and can no longer be used.</em>
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -37,7 +37,7 @@ No further configuration is required. The plugin uses
 for authorization - for additional information see 
 {here}[https://cloud.google.com/logging/docs/agent/authorization].
 
-If your GCE and Logging service are in different project, you can specify the project id in your fluentd configuration by `project_id` parameter like this:
+If your GCE and Logging service are in different project, you can specify the project id in your fluentd configuration by `project_id` parameter like below and add Logging service credentials to your GCE.
 
     <match **>
       type google_cloud


### PR DESCRIPTION
Sometimes our GCE and Logging service are in different project, actually we can set this parameter in conf but not documented.
Pull Request: #137 