### PR TITLE
Allow setting LogEntry trace field via record

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -22,7 +22,7 @@ eos
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
   gem.add_runtime_dependency 'google-api-client', '~> 0.9.0'
-  gem.add_runtime_dependency 'google-cloud-logging', '~> 1.2.1'
+  gem.add_runtime_dependency 'google-cloud-logging', '~> 0.24'
   gem.add_runtime_dependency 'googleauth', '~> 0.4'
   gem.add_runtime_dependency 'grpc', '~> 1.0', '< 1.3'
   gem.add_runtime_dependency 'json', '~> 1.8'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -22,7 +22,7 @@ eos
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
   gem.add_runtime_dependency 'google-api-client', '~> 0.9.0'
-  gem.add_runtime_dependency 'google-cloud-logging', '~> 0.23.2'
+  gem.add_runtime_dependency 'google-cloud-logging', '~> 1.2.1'
   gem.add_runtime_dependency 'googleauth', '~> 0.4'
   gem.add_runtime_dependency 'grpc', '~> 1.0', '< 1.3'
   gem.add_runtime_dependency 'json', '~> 1.8'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -22,8 +22,8 @@ eos
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
   gem.add_runtime_dependency 'google-api-client', '~> 0.9.0'
-  gem.add_runtime_dependency 'google-cloud-logging', '~> 0.24'
-  gem.add_runtime_dependency 'googleauth', '~> 0.4'
+  gem.add_runtime_dependency 'google-cloud-logging', '0.24.1'
+  gem.add_runtime_dependency 'googleauth', '0.5.1'
   gem.add_runtime_dependency 'grpc', '~> 1.0', '< 1.3'
   gem.add_runtime_dependency 'json', '~> 1.8'
 

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -72,6 +72,9 @@ module Fluent
         service: 'ml.googleapis.com',
         resource_type: 'ml_job'
       }
+
+      # Default value for trace_key config param to set "trace" LogEntry field.
+      DEFAULT_TRACE_KEY = 'logging.googleapis.com/trace'
     end
 
     include self::Constants
@@ -86,9 +89,6 @@ module Fluent
 
     # Address of the metadata service.
     METADATA_SERVICE_ADDR = '169.254.169.254'
-
-    # Default value for trace_key config param to set "trace" LogEntry field.
-    DEFAULT_TRACE_KEY = 'logging.googleapis.com/trace'
 
     # Disable this warning to conform to fluentd config_param conventions.
     # rubocop:disable Style/HashSyntax
@@ -629,12 +629,12 @@ module Fluent
           severity = compute_severity(
             entry_resource.type, record, entry_common_labels)
 
-          # Get trace resource for LogEntry "trace" field per specified config.
-          trace_resource = if @keep_trace_key
-                             record[@trace_key]
-                           else
-                             record.delete(@trace_key)
-                           end
+          # Get fully-qualified trace id for LogEntry "trace" field per config.
+          fq_trace_id = if @keep_trace_key
+                          record[@trace_key]
+                        else
+                          record.delete(@trace_key)
+                        end
 
           if @use_grpc
             entry = Google::Logging::V2::LogEntry.new(
@@ -645,7 +645,7 @@ module Fluent
               ),
               severity: grpc_severity(severity)
             )
-            entry.trace = trace_resource if trace_resource
+            entry.trace = fq_trace_id if fq_trace_id
             # If "seconds" is null or not an integer, we will omit the timestamp
             # field and defer the decision on how to handle it to the downstream
             # Logging API. If "nanos" is null or not an integer, it will be set
@@ -671,7 +671,7 @@ module Fluent
                 nanos: ts_nanos
               }
             )
-            entry.trace = trace_resource if trace_resource
+            entry.trace = fq_trace_id if fq_trace_id
             set_http_request(record, entry)
             set_payload(entry_resource.type, record, entry, is_json)
           end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -109,6 +109,12 @@ module Fluent
     config_param :vm_id, :string, :default => nil
     config_param :vm_name, :string, :default => nil
 
+    # Set values from JSON payload with this key to the "trace" LogEntry field
+    config_param :trace_key, :string, :default =>
+      'logging.googleapis.com/trace'
+    # Whether to keep the trace LogEntry field/value in the jsonPayload also
+    config_param :keep_trace_key, :bool, :default => false
+
     # Whether to try to detect if the VM is owned by a "subservice" such as App
     # Engine of Kubernetes, rather than just associating the logs with the
     # compute service of the platform. This currently only has any effect when
@@ -621,15 +627,21 @@ module Fluent
           severity = compute_severity(
             entry_resource.type, record, entry_common_labels)
 
+          # Extract "trace" as LogEntry field according to specified config
+          trace = record[@trace_key]
+          record.delete(@trace_key) unless @keep_trace_key
+
           if @use_grpc
-            entry = Google::Logging::V2::LogEntry.new(
+            entry_data = {
               labels: entry_common_labels,
               resource: Google::Api::MonitoredResource.new(
                 type: entry_resource.type,
                 labels: entry_resource.labels.to_h
               ),
               severity: grpc_severity(severity)
-            )
+            }
+            entry_data[:trace] = trace if trace
+            entry = Google::Logging::V2::LogEntry.new(entry_data)
             # If "seconds" is null or not an integer, we will omit the timestamp
             # field and defer the decision on how to handle it to the downstream
             # Logging API. If "nanos" is null or not an integer, it will be set
@@ -646,7 +658,7 @@ module Fluent
           else
             # Remove the labels if we didn't populate them with anything.
             entry_resource.labels = nil if entry_resource.labels.empty?
-            entry = Google::Apis::LoggingV2beta1::LogEntry.new(
+            entry_data = {
               labels: entry_common_labels,
               resource: entry_resource,
               severity: severity,
@@ -654,7 +666,9 @@ module Fluent
                 seconds: ts_secs,
                 nanos: ts_nanos
               }
-            )
+            }
+            entry_data[:trace] = trace if trace
+            entry = Google::Apis::LoggingV2beta1::LogEntry.new(entry_data)
             set_http_request(record, entry)
             set_payload(entry_resource.type, record, entry, is_json)
           end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1019,7 +1019,7 @@ module BaseTest
     setup_gce_metadata_stubs
     message = log_entry(0)
     trace = 'projects/project-1/traces/1234567890abcdef1234567890abcdef'
-    default_trace_key = 'logging.googleapis.com/trace'
+    default_trace_key = Fluent::GoogleCloudOutput::DEFAULT_TRACE_KEY
     [
       {
         # It leaves trace entry field nil if no trace value sent

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1019,7 +1019,7 @@ module BaseTest
     setup_gce_metadata_stubs
     message = log_entry(0)
     trace = 'projects/project-1/traces/1234567890abcdef1234567890abcdef'
-    default_trace_key = Fluent::GoogleCloudOutput::DEFAULT_TRACE_KEY
+    default_trace_key = DEFAULT_TRACE_KEY
     [
       {
         # It leaves trace entry field nil if no trace value sent
@@ -1126,14 +1126,14 @@ module BaseTest
 
   def setup_auth_stubs
     # Used when loading credentials from a JSON file.
-    stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token')
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token')
       .with(body: hash_including(grant_type: AUTH_GRANT_TYPE))
       .to_return(body: %({"access_token": "#{FAKE_AUTH_TOKEN}"}),
                  status: 200,
                  headers: { 'Content-Length' => FAKE_AUTH_TOKEN.length,
                             'Content-Type' => 'application/json' })
 
-    stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token')
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token')
       .with(body: hash_including(grant_type: 'refresh_token'))
       .to_return(body: %({"access_token": "#{FAKE_AUTH_TOKEN}"}),
                  status: 200,

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -196,6 +196,14 @@ module Constants
     label_map { "name": "#{ML_CONSTANTS[:service]}/job_id/log_area" }
   )
 
+  CONFIG_KEEP_TRACE_KEY_TRUE = %(
+    keep_trace_key true
+  )
+
+  CONFIG_CUSTOM_TRACE_KEY_SPECIFIED = %(
+    trace_key custom_trace_key
+  )
+
   # Service configurations for various services.
   COMPUTE_PARAMS = {
     resource: {


### PR DESCRIPTION
This fixes part of https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/issues/126. This is just for the `trace` field, but I plan to do a similar change for `operation`.

This makes the `trace_key` default to `logging.googleapis.com/trace` to not conflict with any users who happen to use `"trace"` as a log entry field.

There is also a `keep_trace_key` setting to control whether the trace value is retained in the `jsonPayload` in addition to being set on the LogEntry itself. That's in line with the discussion at https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/issues/4.

This upgrades the `google-cloud-logging` gem dependency as the new version was needed to support the `trace` field in the LogEntry proto for gRPC.