### PR TITLE
JSON parsing from a GKE container

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -593,10 +593,13 @@ module Fluent
             group_common_labels.merge(extracted_common_labels)
 
           if entry_resource.type == CONTAINER_CONSTANTS[:resource_type]
-            # Save the timestamp if available, then clear it out to allow for
-            # determining whether we should parse the log or message field.
+            # Save the timestamp and stream if available, then clear it out
+            # to allow for determining whether we should parse the log or
+            # message field.
             timestamp = record.key?('time') ? record['time'] : nil
             record.delete('time')
+            stream = record.key?('stream') ? record['stream'] : nil
+            record.delete('stream')
             # If the log is json, we want to export it as a structured log
             # unless there is additional metadata that would be lost.
             is_json = false
@@ -610,9 +613,12 @@ module Fluent
               record = record_json
               is_json = true
             end
-            # Restore timestamp if necessary.
+            # Restore timestamp and stream if necessary.
             unless record.key?('time') || timestamp.nil?
               record['time'] = timestamp
+            end
+            unless record.key?('stream') || stream.nil?
+              record['stream'] = stream
             end
           end
 


### PR DESCRIPTION
When logging from a Kubernetes cluster on GKE, the logs received by fluentd are those sent by docker, and follow the format:
```json
{
  "log":"2014/09/25 21:15:03 Got request with path wombat\\n",
  "stream":"stderr", 
  "time":"2014-09-25T21:15:03.499185026Z"
}
```

The JSON parsing done by this plugin would be a really simple way to output formatted logs directly from an application.
This PR makes the log sent by docker acceptable for optional JSON-decoding, by putting aside the stream key just like the time key and restoring it after deciding whether or not it should be JSON-decoded