### PR TITLE
Convert timestamp Strings with Integer values to Integers.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -636,6 +636,16 @@ module Fluent
                           record.delete(@trace_key)
                         end
 
+          ts_secs = begin
+                      Integer ts_secs
+                    rescue ArgumentError, TypeError
+                      ts_secs
+                    end
+          ts_nanos = begin
+                       Integer ts_nanos
+                     rescue ArgumentError, TypeError
+                       ts_nanos
+                     end
           if @use_grpc
             entry = Google::Logging::V2::LogEntry.new(
               labels: entry_common_labels,

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -516,6 +516,11 @@ module BaseTest
                'timestampSeconds' => ts.tv_sec, 'timestampNanos' => ts.tv_nsec)
         expected_ts.push(ts)
         emit_index += 1
+        d.emit('message' => log_entry(emit_index),
+               'timestampSeconds' => "#{ts.tv_sec}",
+               'timestampNanos' => "#{ts.tv_nsec}")
+        expected_ts.push(ts)
+        emit_index += 1
         d.run
       end
     end


### PR DESCRIPTION
Fixes the case when timestamp components are parsed out of logs as strings.