### PR TITLE
Get source_location, operation and labels from the record if any are available.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -95,7 +95,7 @@ module Fluent
         .map { |consts| [consts[:resource_type], consts[:metadata_attributes]] }
         .to_h
 
-      # Default values for JSON payload keys to set the "trace "trace",
+      # Default values for JSON payload keys to set the "trace",
       # "sourceLocation", "operation" and "labels" fields in the LogEntry.
       DEFAULT_PAYLOAD_KEY_PREFIX = 'logging.googleapis.com'
       DEFAULT_LABELS_KEY = "#{DEFAULT_PAYLOAD_KEY_PREFIX}/labels"
@@ -1257,11 +1257,8 @@ module Fluent
             begin
               casted_value = send(cast_fn, value)
             rescue TypeError
-              log = <<-eos
-                Failed to #{cast_fn} for {#field_name}.#{original_key}
-                with value #{value.inspect}.
-              eos
-              @log.error log, err
+              @log.error "Failed to #{cast_fn} for #{field_name}." \
+                         "#{original_key} with value #{value.inspect}.", err
               next
             end
             next if casted_value.nil?

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -106,7 +106,7 @@ module Fluent
       # Map from each field name under LogEntry to corresponding variables
       # required to perform field value extraction from the log record.
       LOG_ENTRY_FIELDS_MAP = {
-        'http_request': {
+        'http_request' => {
           # The config to specify label name for field extraction from record.
           payload_key: '@http_request_key',
           # Map from subfields' names to their types.
@@ -130,7 +130,7 @@ module Fluent
           # The non-grpc version class name.
           nongrpc_class: 'Google::Apis::LoggingV2beta1::HttpRequest'
         },
-        'source_location': {
+        'source_location' => {
           payload_key: '@source_location_key',
           fields: [
             %w(file file),
@@ -140,7 +140,7 @@ module Fluent
           grpc_class: 'Google::Logging::V2::LogEntrySourceLocation',
           nongrpc_class: 'Google::Apis::LoggingV2beta1::LogEntrySourceLocation'
         },
-        'operation': {
+        'operation' => {
           payload_key: '@operation_key',
           fields: [
             %w(id id),

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -860,7 +860,8 @@ module BaseTest
   end
 
   def test_subfields_from_record
-    SUBFIELDS.each do |payload_key, destination_key, payload_value|
+    LOG_ENTRY_SUBFIELDS_PARAMS.each do |args|
+      payload_key, destination_key, payload_value = args
       @logs_sent = []
       setup_gce_metadata_stubs
       setup_logging_stubs do
@@ -877,7 +878,8 @@ module BaseTest
   end
 
   def test_subfields_partial_from_record
-    SUBFIELDS.each do |payload_key, destination_key, payload_value|
+    LOG_ENTRY_SUBFIELDS_PARAMS.each do |args|
+      payload_key, destination_key, payload_value = args
       @logs_sent = []
       setup_gce_metadata_stubs
       setup_logging_stubs do
@@ -895,7 +897,7 @@ module BaseTest
   end
 
   def test_subfields_when_not_hash
-    SUBFIELDS.each do |payload_key, destination_key, _|
+    LOG_ENTRY_SUBFIELDS_PARAMS.each do |payload_key, destination_key, _|
       @logs_sent = []
       setup_gce_metadata_stubs
       setup_logging_stubs do
@@ -926,6 +928,7 @@ module BaseTest
       verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
         assert_equal http_request_message_with_absent_referer,
                      entry['httpRequest'], entry
+        assert_nil get_fields(entry['jsonPayload'])['httpRequest'], entry
       end
     end
   end
@@ -962,9 +965,7 @@ module BaseTest
       end
       verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
         assert_equal HTTP_REQUEST_MESSAGE, entry['httpRequest'], entry
-        fields = get_fields(entry['jsonPayload'])
-        request = get_fields(get_struct(fields['httpRequest']))
-        assert_equal input, get_string(request['latency']), entry
+        assert_nil get_fields(entry['jsonPayload'])['httpRequest'], entry
       end
     end
   end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -959,6 +959,133 @@ module BaseTest
     end
   end
 
+  def test_source_location_from_record
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit('sourceLocation' => SOURCE_LOCATION_MESSAGE)
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'sourceLocation') do |entry|
+      assert_equal SOURCE_LOCATION_MESSAGE, entry['sourceLocation'], entry
+      assert_nil get_fields(entry['jsonPayload'])['sourceLocation'], entry
+    end
+  end
+
+  def test_source_location_partial_from_record
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit('sourceLocation' => SOURCE_LOCATION_MESSAGE.merge(
+        'otherKey' => 'value'))
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'sourceLocation') do |entry|
+      assert_equal SOURCE_LOCATION_MESSAGE, entry['sourceLocation'], entry
+      fields = get_fields(entry['jsonPayload'])
+      request = get_fields(get_struct(fields['sourceLocation']))
+      assert_equal 'value', get_string(request['otherKey']), entry
+    end
+  end
+
+  def test_source_location_when_not_hash
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit('sourceLocation' => 'a_string')
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      fields = get_fields(entry['jsonPayload'])
+      assert_equal 'a_string', get_string(fields['sourceLocation']), entry
+      assert_nil entry['sourceLocation'], entry
+    end
+  end
+
+  def test_operation_from_record
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit('operation' => OPERATION_MESSAGE)
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'operation') do |entry|
+      assert_equal OPERATION_MESSAGE, entry['operation'], entry
+      assert_nil get_fields(entry['jsonPayload'])['operation'], entry
+    end
+  end
+
+  def test_operation_partial_from_record
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit('operation' => OPERATION_MESSAGE.merge(
+        'otherKey' => 'value'))
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'operation') do |entry|
+      assert_equal OPERATION_MESSAGE, entry['operation'], entry
+      fields = get_fields(entry['jsonPayload'])
+      request = get_fields(get_struct(fields['operation']))
+      assert_equal 'value', get_string(request['otherKey']), entry
+    end
+  end
+
+  def test_operation_when_not_hash
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit('operation' => 'a_string')
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      fields = get_fields(entry['jsonPayload'])
+      assert_equal 'a_string', get_string(fields['operation']), entry
+      assert_nil entry['operation'], entry
+    end
+  end
+
+  def test_labels_from_record
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit('labels' => CUSTOM_LABELS_MESSAGE)
+      d.run
+    end
+    labels = COMPUTE_PARAMS[:labels].merge(CUSTOM_LABELS_MESSAGE)
+    params = COMPUTE_PARAMS.merge(labels: labels)
+    verify_log_entries(1, params, 'labels') do |entry|
+      assert_nil get_fields(entry['jsonPayload'])['labels'], entry
+    end
+  end
+
+  def test_labels_from_record_conflict
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit('labels' => { CONFLICTING_LABEL_KEY => 'a_string' })
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      fields = get_fields(entry['jsonPayload'])
+      labels = get_fields(get_struct(fields['labels']))
+      assert_equal('a_string', get_string(labels[CONFLICTING_LABEL_KEY]), entry)
+    end
+  end
+
+  def test_labels_from_record_when_not_hash
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit('labels' => 'a_string')
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      fields = get_fields(entry['jsonPayload'])
+      assert_equal 'a_string', get_string(fields['labels']), entry
+    end
+  end
+
   def test_log_entry_trace_field
     setup_gce_metadata_stubs
     message = log_entry(0)

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -963,12 +963,13 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit('sourceLocation' => SOURCE_LOCATION_MESSAGE)
+      d.emit(DEFAULT_SOURCE_LOCATION_KEY => SOURCE_LOCATION_MESSAGE)
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'sourceLocation') do |entry|
       assert_equal SOURCE_LOCATION_MESSAGE, entry['sourceLocation'], entry
-      assert_nil get_fields(entry['jsonPayload'])['sourceLocation'], entry
+      fields = get_fields(entry['jsonPayload'])
+      assert_nil fields[DEFAULT_SOURCE_LOCATION_KEY], entry
     end
   end
 
@@ -976,14 +977,14 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit('sourceLocation' => SOURCE_LOCATION_MESSAGE.merge(
-        'otherKey' => 'value'))
+      sl = SOURCE_LOCATION_MESSAGE.merge('otherKey' => 'value')
+      d.emit(DEFAULT_SOURCE_LOCATION_KEY => sl)
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'sourceLocation') do |entry|
       assert_equal SOURCE_LOCATION_MESSAGE, entry['sourceLocation'], entry
       fields = get_fields(entry['jsonPayload'])
-      request = get_fields(get_struct(fields['sourceLocation']))
+      request = get_fields(get_struct(fields[DEFAULT_SOURCE_LOCATION_KEY]))
       assert_equal 'value', get_string(request['otherKey']), entry
     end
   end
@@ -992,12 +993,12 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit('sourceLocation' => 'a_string')
+      d.emit(DEFAULT_SOURCE_LOCATION_KEY => 'a_string')
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
-      assert_equal 'a_string', get_string(fields['sourceLocation']), entry
+      field = get_fields(entry['jsonPayload'])[DEFAULT_SOURCE_LOCATION_KEY]
+      assert_equal 'a_string', get_string(field), entry
       assert_nil entry['sourceLocation'], entry
     end
   end
@@ -1006,12 +1007,12 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit('operation' => OPERATION_MESSAGE)
+      d.emit(DEFAULT_OPERATION_KEY => OPERATION_MESSAGE)
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'operation') do |entry|
       assert_equal OPERATION_MESSAGE, entry['operation'], entry
-      assert_nil get_fields(entry['jsonPayload'])['operation'], entry
+      assert_nil get_fields(entry['jsonPayload'])[DEFAULT_OPERATION_KEY], entry
     end
   end
 
@@ -1019,14 +1020,14 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit('operation' => OPERATION_MESSAGE.merge(
-        'otherKey' => 'value'))
+      msg = OPERATION_MESSAGE.merge('otherKey' => 'value')
+      d.emit(DEFAULT_OPERATION_KEY => msg)
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'operation') do |entry|
       assert_equal OPERATION_MESSAGE, entry['operation'], entry
       fields = get_fields(entry['jsonPayload'])
-      request = get_fields(get_struct(fields['operation']))
+      request = get_fields(get_struct(fields[DEFAULT_OPERATION_KEY]))
       assert_equal 'value', get_string(request['otherKey']), entry
     end
   end
@@ -1035,12 +1036,12 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit('operation' => 'a_string')
+      d.emit(DEFAULT_OPERATION_KEY => 'a_string')
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
       fields = get_fields(entry['jsonPayload'])
-      assert_equal 'a_string', get_string(fields['operation']), entry
+      assert_equal 'a_string', get_string(fields[DEFAULT_OPERATION_KEY]), entry
       assert_nil entry['operation'], entry
     end
   end
@@ -1049,13 +1050,13 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit('labels' => CUSTOM_LABELS_MESSAGE)
+      d.emit(DEFAULT_LABELS_KEY => CUSTOM_LABELS_MESSAGE)
       d.run
     end
     labels = COMPUTE_PARAMS[:labels].merge(CUSTOM_LABELS_MESSAGE)
     params = COMPUTE_PARAMS.merge(labels: labels)
     verify_log_entries(1, params, 'labels') do |entry|
-      assert_nil get_fields(entry['jsonPayload'])['labels'], entry
+      assert_nil get_fields(entry['jsonPayload'])[DEFAULT_LABELS_KEY], entry
     end
   end
 
@@ -1063,12 +1064,12 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit('labels' => { CONFLICTING_LABEL_KEY => 'a_string' })
+      d.emit(DEFAULT_LABELS_KEY => { CONFLICTING_LABEL_KEY => 'a_string' })
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
       fields = get_fields(entry['jsonPayload'])
-      labels = get_fields(get_struct(fields['labels']))
+      labels = get_fields(get_struct(fields[DEFAULT_LABELS_KEY]))
       assert_equal('a_string', get_string(labels[CONFLICTING_LABEL_KEY]), entry)
     end
   end
@@ -1077,12 +1078,12 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
-      d.emit('labels' => 'a_string')
+      d.emit(DEFAULT_LABELS_KEY => 'a_string')
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
       fields = get_fields(entry['jsonPayload'])
-      assert_equal 'a_string', get_string(fields['labels']), entry
+      assert_equal 'a_string', get_string(fields[DEFAULT_LABELS_KEY]), entry
     end
   end
 

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -430,6 +430,23 @@ module Constants
     'cacheValidatedWithOriginServer' => true
   }
 
+  SOURCE_LOCATION_MESSAGE = {
+    'file' => 'source/file',
+    'function' => 'my_function',
+    'line' => 18
+  }
+
+  OPERATION_MESSAGE = {
+    'id' => 'op_id',
+    'producer' => 'my/app',
+    'last' => true
+  }
+
+  CUSTOM_LABELS_MESSAGE = {
+    'customKey' => 'value'
+  }
+  CONFLICTING_LABEL_KEY = "#{COMPUTE_CONSTANTS[:service]}/resource_name"
+
   # Tags and their sanitized and encoded version.
   VALID_TAGS = {
     'test' => 'test',

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -442,12 +442,12 @@ module Constants
     'last' => true
   }
 
-  LOG_ENTRY_SUBFIELDS_PARAMS = [
+  LOG_ENTRY_SUBFIELDS_PARAMS = {
     # payload key, destination key, payload value
-    [DEFAULT_HTTP_REQUEST_KEY, 'httpRequest', HTTP_REQUEST_MESSAGE],
-    [DEFAULT_SOURCE_LOCATION_KEY, 'sourceLocation', SOURCE_LOCATION_MESSAGE],
-    [DEFAULT_OPERATION_KEY, 'operation', OPERATION_MESSAGE]
-  ]
+    DEFAULT_HTTP_REQUEST_KEY => ['httpRequest', HTTP_REQUEST_MESSAGE],
+    DEFAULT_SOURCE_LOCATION_KEY => ['sourceLocation', SOURCE_LOCATION_MESSAGE],
+    DEFAULT_OPERATION_KEY => ['operation', OPERATION_MESSAGE]
+  }
 
   CUSTOM_LABELS_MESSAGE = {
     'customKey' => 'value'

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -430,19 +430,23 @@ module Constants
     'cacheValidatedWithOriginServer' => true
   }
 
-  SUBFIELDS = [
+  SOURCE_LOCATION_MESSAGE = {
+    'file' => 'source/file',
+    'function' => 'my_function',
+    'line' => 18
+  }
+
+  OPERATION_MESSAGE = {
+    'id' => 'op_id',
+    'producer' => 'my/app',
+    'last' => true
+  }
+
+  LOG_ENTRY_SUBFIELDS_PARAMS = [
     # payload key, destination key, payload value
     [DEFAULT_HTTP_REQUEST_KEY, 'httpRequest', HTTP_REQUEST_MESSAGE],
-    [DEFAULT_SOURCE_LOCATION_KEY, 'sourceLocation', {
-      'file' => 'source/file',
-      'function' => 'my_function',
-      'line' => 18
-    }],
-    [DEFAULT_OPERATION_KEY, 'operation', {
-      'id' => 'op_id',
-      'producer' => 'my/app',
-      'last' => true
-    }]
+    [DEFAULT_SOURCE_LOCATION_KEY, 'sourceLocation', SOURCE_LOCATION_MESSAGE],
+    [DEFAULT_OPERATION_KEY, 'operation', OPERATION_MESSAGE]
   ]
 
   CUSTOM_LABELS_MESSAGE = {

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -430,17 +430,20 @@ module Constants
     'cacheValidatedWithOriginServer' => true
   }
 
-  SOURCE_LOCATION_MESSAGE = {
-    'file' => 'source/file',
-    'function' => 'my_function',
-    'line' => 18
-  }
-
-  OPERATION_MESSAGE = {
-    'id' => 'op_id',
-    'producer' => 'my/app',
-    'last' => true
-  }
+  SUBFIELDS = [
+    # payload key, destination key, payload value
+    [DEFAULT_HTTP_REQUEST_KEY, 'httpRequest', HTTP_REQUEST_MESSAGE],
+    [DEFAULT_SOURCE_LOCATION_KEY, 'sourceLocation', {
+      'file' => 'source/file',
+      'function' => 'my_function',
+      'line' => 18
+    }],
+    [DEFAULT_OPERATION_KEY, 'operation', {
+      'id' => 'op_id',
+      'producer' => 'my/app',
+      'last' => true
+    }]
+  ]
 
   CUSTOM_LABELS_MESSAGE = {
     'customKey' => 'value'


### PR DESCRIPTION
Dispatch the data to the correct fields for `sourceLocation` and `operation`, like it's done for `httpRequest`

I have also merged the `labels` into the record labels, if no conflict is present

fixes #126 