### PR TITLE
Make JSON detection a config option, rather than GKE-only.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -456,8 +456,8 @@ module Fluent
             # If the log is json, we want to export it as a structured log
             # unless there is additional metadata that would be lost.
             record_json = nil
-            if record.length == 1 then
-              ['log', 'message', 'msg'].each do |field|
+            if record.length == 1
+              %w(log message msg).each do |field|
                 if record.key?(field)
                   record_json = parse_json_or_nil(record[field])
                 end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -305,20 +305,83 @@ module BaseTest
   def test_structured_payload_json_log
     setup_gce_metadata_stubs
     setup_logging_stubs do
-      d = create_driver
-      json_string = '{"msg": "test log entry 0", "tag2": "test", "data": 5000}'
+      d = create_driver(APPLICATION_DEFAULT_CONFIG)
+      json_string = '{"msg": "test log entry 0", "tag2": "test", ' \
+                    '"data": 5000, "some_null_field": null}'
       d.emit('message' => 'notJSON ' + json_string)
+      d.emit('log' => 'notJSON ' + json_string)
+      d.emit('msg' => 'notJSON ' + json_string)
       d.emit('message' => json_string)
-      d.emit('message' => "\t" + json_string)
-      d.emit('message' => '  ' + json_string)
+      d.emit('log' => json_string)
+      d.emit('msg' => json_string)
+      d.emit('message' => "  \r\n \t" + json_string)
+      d.emit('log' => "  \r\n \t" + json_string)
+      d.emit('msg' => "  \r\n \t" + json_string)
       d.run
     end
-    verify_log_entries(4, COMPUTE_PARAMS, '') do |entry|
-      assert entry.key?('textPayload'), 'Entry did not have textPayload'
+    log_index = 0
+    verify_log_entries(9, COMPUTE_PARAMS, '') do |entry|
+      log_index += 1
+      if log_index % 3 == 1
+        assert entry.key?('textPayload'),
+          "Entry ##{log_index} #{entry} did not have textPayload"
+      else
+        assert entry.key?('jsonPayload'),
+          "Entry ##{log_index} #{entry} did not have jsonPayload"
+        fields = get_fields(entry['jsonPayload'])
+        assert !fields.key?('tag2'), "Did not expect tag2"
+        assert !fields.key?('data'), "Did not expect data"
+        assert !fields.key?('some_null_field'),
+          "Did not expect some_null_field"
+      end
     end
   end
 
-  def test_structured_payload_json_container_log
+  def test_structured_payload_json_log_detect_json
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver(DETECT_JSON_CONFIG)
+      json_string = '{"msg": "test log entry 0", "tag2": "test", ' \
+                    '"data": 5000, "some_null_field": null}'
+      d.emit('message' => 'notJSON ' + json_string)
+      d.emit('log' => 'notJSON ' + json_string)
+      d.emit('msg' => 'notJSON ' + json_string)
+      d.emit('message' => json_string)
+      d.emit('log' => json_string)
+      d.emit('msg' => json_string)
+      d.emit('message' => "  \r\n \t" + json_string)
+      d.emit('log' => "  \r\n \t" + json_string)
+      d.emit('msg' => "  \r\n \t" + json_string)
+      d.run
+    end
+    log_index = 0
+    verify_log_entries(9, COMPUTE_PARAMS, '') do |entry|
+      log_index += 1
+      if log_index == 1
+        assert entry.key?('textPayload'),
+          "Entry ##{log_index} #{entry} did not have textPayload"
+      elsif log_index < 4
+        assert entry.key?('jsonPayload'),
+          "Entry ##{log_index} #{entry} did not have jsonPayload"
+        fields = get_fields(entry['jsonPayload'])
+        assert !fields.key?('tag2'), "Did not expect tag2"
+        assert !fields.key?('data'), "Did not expect data"
+        assert !fields.key?('some_null_field'),
+          "Did not expect some_null_field"
+      else
+        assert entry.key?('jsonPayload'),
+          "Entry ##{log_index} #{entry} did not have jsonPayload"
+        fields = get_fields(entry['jsonPayload'])
+        assert_equal 4, fields.size, entry
+        assert_equal 'test log entry 0', get_string(fields['msg']), entry
+        assert_equal 'test', get_string(fields['tag2']), entry
+        assert_equal 5000, get_number(fields['data']), entry
+        assert_equal null_value, fields['some_null_field'], entry
+      end
+    end
+  end
+
+  def test_structured_payload_json_log_container
     setup_gce_metadata_stubs
     setup_container_metadata_stubs
     setup_logging_stubs do
@@ -331,13 +394,34 @@ module BaseTest
       d.run
     end
     log_index = 0
-    verify_log_entries(
-      3, CONTAINER_FROM_METADATA_PARAMS, '') do |entry|
+    verify_log_entries(3, CONTAINER_FROM_METADATA_PARAMS, '') do |entry|
+      log_index += 1
+      assert entry.key?('textPayload'),
+        "Entry ##{log_index} #{entry} did not have textPayload"
+    end
+  end
+
+  def test_structured_payload_json_log_detect_json_container
+    setup_gce_metadata_stubs
+    setup_container_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver(DETECT_JSON_CONFIG, CONTAINER_TAG)
+      json_string = '{"msg": "test log entry 0", "tag2": "test", ' \
+                    '"data": 5000, "some_null_field": null}'
+      d.emit(container_log_entry_with_metadata('notJSON' + json_string))
+      d.emit(container_log_entry_with_metadata(json_string))
+      d.emit(container_log_entry_with_metadata("  \r\n \t" + json_string))
+      d.run
+    end
+    log_index = 0
+    verify_log_entries(3, CONTAINER_FROM_METADATA_PARAMS, '') do |entry|
       log_index += 1
       if log_index == 1
-        assert entry.key?('textPayload'), 'Entry did not have textPayload'
+        assert entry.key?('textPayload'),
+          "Entry ##{log_index} #{entry} did not have textPayload"
       else
-        assert entry.key?('jsonPayload'), 'Entry did not have jsonPayload'
+        assert entry.key?('jsonPayload'),
+          "Entry ##{log_index} #{entry} did not have jsonPayload"
         fields = get_fields(entry['jsonPayload'])
         assert_equal 4, fields.size, entry
         assert_equal 'test log entry 0', get_string(fields['msg']), entry
@@ -742,7 +826,7 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_container_metadata_stubs
     setup_logging_stubs do
-      d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_TAG)
+      d = create_driver(DETECT_JSON_CONFIG, CONTAINER_TAG)
       d.emit(container_log_entry_with_metadata('{"msg": "test log entry 0", ' \
                                                '"tag2": "test", "data": ' \
                                                '5000, "severity": "WARNING"}'))
@@ -765,7 +849,7 @@ module BaseTest
     setup_gce_metadata_stubs
     setup_container_metadata_stubs
     setup_logging_stubs do
-      d = create_driver(APPLICATION_DEFAULT_CONFIG, CONTAINER_TAG)
+      d = create_driver(DETECT_JSON_CONFIG, CONTAINER_TAG)
       d.emit(container_log_entry('{"msg": "test log entry 0", ' \
                                  '"tag2": "test", "data": 5000, ' \
                                  '"severity": "W"}'))

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -324,15 +324,15 @@ module BaseTest
       log_index += 1
       if log_index % 3 == 1
         assert entry.key?('textPayload'),
-          "Entry ##{log_index} #{entry} did not have textPayload"
+               "Entry ##{log_index} #{entry} did not have textPayload"
       else
         assert entry.key?('jsonPayload'),
-          "Entry ##{log_index} #{entry} did not have jsonPayload"
+               "Entry ##{log_index} #{entry} did not have jsonPayload"
         fields = get_fields(entry['jsonPayload'])
-        assert !fields.key?('tag2'), "Did not expect tag2"
-        assert !fields.key?('data'), "Did not expect data"
+        assert !fields.key?('tag2'), 'Did not expect tag2'
+        assert !fields.key?('data'), 'Did not expect data'
         assert !fields.key?('some_null_field'),
-          "Did not expect some_null_field"
+               'Did not expect some_null_field'
       end
     end
   end
@@ -359,18 +359,18 @@ module BaseTest
       log_index += 1
       if log_index == 1
         assert entry.key?('textPayload'),
-          "Entry ##{log_index} #{entry} did not have textPayload"
+               "Entry ##{log_index} #{entry} did not have textPayload"
       elsif log_index < 4
         assert entry.key?('jsonPayload'),
-          "Entry ##{log_index} #{entry} did not have jsonPayload"
+               "Entry ##{log_index} #{entry} did not have jsonPayload"
         fields = get_fields(entry['jsonPayload'])
-        assert !fields.key?('tag2'), "Did not expect tag2"
-        assert !fields.key?('data'), "Did not expect data"
+        assert !fields.key?('tag2'), 'Did not expect tag2'
+        assert !fields.key?('data'), 'Did not expect data'
         assert !fields.key?('some_null_field'),
-          "Did not expect some_null_field"
+               'Did not expect some_null_field'
       else
         assert entry.key?('jsonPayload'),
-          "Entry ##{log_index} #{entry} did not have jsonPayload"
+               "Entry ##{log_index} #{entry} did not have jsonPayload"
         fields = get_fields(entry['jsonPayload'])
         assert_equal 4, fields.size, entry
         assert_equal 'test log entry 0', get_string(fields['msg']), entry
@@ -397,7 +397,7 @@ module BaseTest
     verify_log_entries(3, CONTAINER_FROM_METADATA_PARAMS, '') do |entry|
       log_index += 1
       assert entry.key?('textPayload'),
-        "Entry ##{log_index} #{entry} did not have textPayload"
+             "Entry ##{log_index} #{entry} did not have textPayload"
     end
   end
 
@@ -418,10 +418,10 @@ module BaseTest
       log_index += 1
       if log_index == 1
         assert entry.key?('textPayload'),
-          "Entry ##{log_index} #{entry} did not have textPayload"
+               "Entry ##{log_index} #{entry} did not have textPayload"
       else
         assert entry.key?('jsonPayload'),
-          "Entry ##{log_index} #{entry} did not have jsonPayload"
+               "Entry ##{log_index} #{entry} did not have jsonPayload"
         fields = get_fields(entry['jsonPayload'])
         assert_equal 4, fields.size, entry
         assert_equal 'test log entry 0', get_string(fields['msg']), entry

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -120,6 +120,10 @@ module Constants
   APPLICATION_DEFAULT_CONFIG = %(
   )
 
+  DETECT_JSON_CONFIG = %(
+    detect_json true
+  )
+
   # rubocop:disable Metrics/LineLength
   PRIVATE_KEY_CONFIG = %(
      auth_method private_key


### PR DESCRIPTION
Also adds `'msg'` as a supported text payload key for JSON detection.
@meltsufin FYI. Should allow #89 to be fixed on the AppEngine side.
@crassirostris FYI.