### PR TITLE
Remove keep_trace_key config option

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -114,8 +114,6 @@ module Fluent
 
     # Set values from JSON payload with this key to the "trace" LogEntry field.
     config_param :trace_key, :string, :default => DEFAULT_TRACE_KEY
-    # Whether to also keep the trace key/value in the payload.
-    config_param :keep_trace_key, :bool, :default => false
 
     # Whether to try to detect if the VM is owned by a "subservice" such as App
     # Engine of Kubernetes, rather than just associating the logs with the
@@ -630,11 +628,7 @@ module Fluent
             entry_resource.type, record, entry_common_labels)
 
           # Get fully-qualified trace id for LogEntry "trace" field per config.
-          fq_trace_id = if @keep_trace_key
-                          record[@trace_key]
-                        else
-                          record.delete(@trace_key)
-                        end
+          fq_trace_id = record.delete(@trace_key)
 
           ts_secs = begin
                       Integer ts_secs

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1020,7 +1020,7 @@ module BaseTest
     end
   end
 
-  def test_trace_field_assignment
+  def test_log_entry_trace_field
     setup_gce_metadata_stubs
     message = log_entry(0)
     trace = 'projects/project-1/traces/1234567890abcdef1234567890abcdef'
@@ -1029,24 +1029,28 @@ module BaseTest
         # It leaves trace entry field nil if no trace value sent.
         driver_config: APPLICATION_DEFAULT_CONFIG,
         emitted_log: { 'msg' => message },
+        expected_fields: { 'msg' => message },
         expected_trace_value: nil
       },
       {
         # By default, it sets trace via Google-specific key.
         driver_config: APPLICATION_DEFAULT_CONFIG,
         emitted_log: { 'msg' => message, DEFAULT_TRACE_KEY => trace },
+        expected_fields: { 'msg' => message },
         expected_trace_value: trace
       },
       {
         # It allows setting the trace via a custom configured key.
         driver_config: CONFIG_CUSTOM_TRACE_KEY_SPECIFIED,
         emitted_log: { 'msg' => message, 'custom_trace_key' => trace },
+        expected_fields: { 'msg' => message },
         expected_trace_value: trace
       },
       {
         # It no longer sets trace by the default key if custom key specified.
         driver_config: CONFIG_CUSTOM_TRACE_KEY_SPECIFIED,
         emitted_log: { 'msg' => message, DEFAULT_TRACE_KEY => trace },
+        expected_fields: { 'msg' => message, DEFAULT_TRACE_KEY => trace },
         expected_trace_value: nil
       }
     ].each do |input|
@@ -1058,26 +1062,13 @@ module BaseTest
       end
       verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
         assert_equal input[:expected_trace_value], entry['trace'], input
+
+        fields = get_fields(entry['jsonPayload'])
+        assert_equal input[:expected_fields].size, fields.size, input
+        fields.each do |key, value|
+          assert_equal input[:expected_fields][key], get_string(value), input
+        end
       end
-    end
-  end
-
-  def test_trace_removal_from_json_payload
-    setup_gce_metadata_stubs
-    message = log_entry(0)
-    trace = 'projects/project-1/traces/1234567890abcdef1234567890abcdef'
-
-    setup_logging_stubs do
-      @logs_sent = []
-      d = create_driver(APPLICATION_DEFAULT_CONFIG)
-      d.emit('msg' => message, DEFAULT_TRACE_KEY => trace)
-      d.run
-    end
-
-    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
-      assert_equal 1, fields.size
-      assert_equal message, get_string(fields['msg'])
     end
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1066,34 +1066,18 @@ module BaseTest
     setup_gce_metadata_stubs
     message = log_entry(0)
     trace = 'projects/project-1/traces/1234567890abcdef1234567890abcdef'
-    [
-      {
-        # By default, it removes trace value from jsonPayload.
-        driver_config: APPLICATION_DEFAULT_CONFIG,
-        emitted_log: { 'msg' => message, DEFAULT_TRACE_KEY => trace },
-        expected_json_payload: { 'msg' => message }
-      },
-      {
-        # It keeps the trace value in jsonPayload if keep_trace_key set to true.
-        driver_config: CONFIG_KEEP_TRACE_KEY_TRUE,
-        emitted_log: { 'msg' => message, DEFAULT_TRACE_KEY => trace },
-        expected_json_payload: { 'msg' => message, DEFAULT_TRACE_KEY => trace }
-      }
-    ].each do |input|
-      setup_logging_stubs do
-        @logs_sent = []
-        d = create_driver(input[:driver_config])
-        d.emit(input[:emitted_log])
-        d.run
-      end
-      verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-        fields = get_fields(entry['jsonPayload'])
-        assert_equal input[:expected_json_payload].size, fields.size, input
-        fields.each do |key, value|
-          assert_equal(input[:expected_json_payload][key],
-                       get_string(value), input)
-        end
-      end
+
+    setup_logging_stubs do
+      @logs_sent = []
+      d = create_driver(APPLICATION_DEFAULT_CONFIG)
+      d.emit('msg' => message, DEFAULT_TRACE_KEY => trace)
+      d.run
+    end
+
+    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      fields = get_fields(entry['jsonPayload'])
+      assert_equal 1, fields.size
+      assert_equal message, get_string(fields['msg'])
     end
   end
 

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -196,10 +196,6 @@ module Constants
     label_map { "name": "#{ML_CONSTANTS[:service]}/job_id/log_area" }
   )
 
-  CONFIG_KEEP_TRACE_KEY_TRUE = %(
-    keep_trace_key true
-  )
-
   CONFIG_CUSTOM_TRACE_KEY_SPECIFIED = %(
     trace_key custom_trace_key
   )


### PR DESCRIPTION
Per suggestion by @qingling128 that we remove this config option (see 
https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/145#issuecomment-321007748).

This new config option did not end up getting released to customers, so I think we are safe to remove it now before the next release goes out.