### PR TITLE
Revert support for labels in log entry.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -98,7 +98,6 @@ module Fluent
       # Default values for JSON payload keys to set the "trace",
       # "sourceLocation", "operation" and "labels" fields in the LogEntry.
       DEFAULT_PAYLOAD_KEY_PREFIX = 'logging.googleapis.com'
-      DEFAULT_LABELS_KEY = "#{DEFAULT_PAYLOAD_KEY_PREFIX}/labels"
       DEFAULT_HTTP_REQUEST_KEY = 'httpRequest'
       DEFAULT_OPERATION_KEY = "#{DEFAULT_PAYLOAD_KEY_PREFIX}/operation"
       DEFAULT_SOURCE_LOCATION_KEY =
@@ -192,7 +191,6 @@ module Fluent
     config_param :vm_name, :string, :default => nil
 
     # Map keys from a JSON payload to corresponding LogEntry fields.
-    config_param :labels_key, :string, :default => DEFAULT_LABELS_KEY
     config_param :http_request_key, :string, :default =>
       DEFAULT_HTTP_REQUEST_KEY
     config_param :operation_key, :string, :default => DEFAULT_OPERATION_KEY
@@ -523,7 +521,6 @@ module Fluent
           entry.trace = fq_trace_id if fq_trace_id
 
           set_log_entry_fields(record, entry)
-          set_labels(record, entry)
 
           if @use_grpc
             set_payload_grpc(entry_resource.type, record, entry, is_json)
@@ -1283,20 +1280,6 @@ module Fluent
           @log.error "Failed to set log entry field for #{field_name}.", err
         end
       end
-    end
-
-    def set_labels(record, entry)
-      record_labels = record[@labels_key]
-      return nil unless record_labels.is_a?(Hash)
-
-      record_labels.each do |key, value|
-        unless entry.labels.key?(key)
-          record_labels.delete(key)
-          entry.labels[key] = value
-        end
-      end
-
-      record.delete(@labels_key) if record_labels.empty?
     end
 
     # Values permitted by the API for 'severity' (which is an enum).

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -952,47 +952,6 @@ module BaseTest
     end
   end
 
-  def test_labels_from_record
-    setup_gce_metadata_stubs
-    setup_logging_stubs do
-      d = create_driver
-      d.emit(DEFAULT_LABELS_KEY => CUSTOM_LABELS_MESSAGE)
-      d.run
-    end
-    labels = COMPUTE_PARAMS[:labels].merge(CUSTOM_LABELS_MESSAGE)
-    params = COMPUTE_PARAMS.merge(labels: labels)
-    verify_log_entries(1, params, 'labels') do |entry|
-      assert_nil get_fields(entry['jsonPayload'])[DEFAULT_LABELS_KEY], entry
-    end
-  end
-
-  def test_labels_from_record_conflict
-    setup_gce_metadata_stubs
-    setup_logging_stubs do
-      d = create_driver
-      d.emit(DEFAULT_LABELS_KEY => { CONFLICTING_LABEL_KEY => 'a_string' })
-      d.run
-    end
-    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
-      labels = get_fields(get_struct(fields[DEFAULT_LABELS_KEY]))
-      assert_equal('a_string', get_string(labels[CONFLICTING_LABEL_KEY]), entry)
-    end
-  end
-
-  def test_labels_from_record_when_not_hash
-    setup_gce_metadata_stubs
-    setup_logging_stubs do
-      d = create_driver
-      d.emit(DEFAULT_LABELS_KEY => 'a_string')
-      d.run
-    end
-    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
-      assert_equal 'a_string', get_string(fields[DEFAULT_LABELS_KEY]), entry
-    end
-  end
-
   def test_log_entry_trace_field
     setup_gce_metadata_stubs
     message = log_entry(0)


### PR DESCRIPTION
The extraction of `labels` field from the record is kind of a major feature, and should go through product first. Reverting this part of the changes that was originally added in https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/145.