### PR TITLE
Add severity translations for java.util.logging.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1285,6 +1285,7 @@ module Fluent
     # Translates other severity strings to one of the valid values above.
     SEVERITY_TRANSLATIONS = {
       # log4j levels (both current and obsolete).
+      'SEVERE' => 'ERROR',
       'WARN' => 'WARNING',
       'FATAL' => 'CRITICAL',
       'TRACE' => 'DEBUG',

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1285,7 +1285,6 @@ module Fluent
     # Translates other severity strings to one of the valid values above.
     SEVERITY_TRANSLATIONS = {
       # log4j levels (both current and obsolete).
-      'SEVERE' => 'ERROR',
       'WARN' => 'WARNING',
       'FATAL' => 'CRITICAL',
       'TRACE' => 'DEBUG',
@@ -1293,6 +1292,9 @@ module Fluent
       'FINE' => 'DEBUG',
       'FINER' => 'DEBUG',
       'FINEST' => 'DEBUG',
+      # java.util.logging levels (only missing ones from above listed).
+      'SEVERE' => 'ERROR',
+      'CONFIG' => 'DEBUG',
       # nginx levels (only missing ones from above listed).
       'CRIT' => 'CRITICAL',
       'EMERG' => 'EMERGENCY',

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -185,6 +185,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
     # synonyms for existing log levels
     assert_equal('ERROR', test_obj.parse_severity('ERR'))
+    assert_equal('ERROR', test_obj.parse_severity('SEVERE'))
     assert_equal('WARNING', test_obj.parse_severity('WARN'))
     assert_equal('CRITICAL', test_obj.parse_severity('FATAL'))
     assert_equal('DEBUG', test_obj.parse_severity('TRACE'))

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -193,6 +193,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     assert_equal('DEBUG', test_obj.parse_severity('FINE'))
     assert_equal('DEBUG', test_obj.parse_severity('FINER'))
     assert_equal('DEBUG', test_obj.parse_severity('FINEST'))
+    assert_equal('DEBUG', test_obj.parse_severity('CONFIG'))
 
     # single letters.
     assert_equal('DEBUG', test_obj.parse_severity('D'))


### PR DESCRIPTION
Added severity translation from "[SEVERE](https://docs.oracle.com/javase/8/docs/api/java/util/logging/Level.html#SEVERE)" to "[ERROR](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity)."