### PR TITLE
solution to #131 truncated timestamps

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1518,7 +1518,7 @@ module Fluent
     end
 
     def format(tag, time, record)
-      [tag, time, record].to_msgpack
+      Fluent::Engine.msgpack_factory.packer.write([tag, time, record]).to_s
     end
 
     # Given a tag, returns the corresponding valid tag if possible, or nil if


### PR DESCRIPTION
#131 by @mururu and @sayap

Tested by editing installed agent plugin code. Saw correct timestamps start to show up for fluentd log entries in Google Cloud Logging webapp.