### PR TITLE
Upgrade google-api-client to 0.14.5 and google-cloud-logging to 1.2.3.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -21,8 +21,8 @@ eos
 
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
-  gem.add_runtime_dependency 'google-api-client', '~> 0.14.5'
-  gem.add_runtime_dependency 'google-cloud-logging', '~> 1.2.3'
+  gem.add_runtime_dependency 'google-api-client', '~> 0.14'
+  gem.add_runtime_dependency 'google-cloud-logging', '~> 1.2', '>= 1.2.3'
   gem.add_runtime_dependency 'googleauth', '~> 0.4', '< 0.5.2'
   gem.add_runtime_dependency 'grpc', '~> 1.0', '< 1.3'
   gem.add_runtime_dependency 'json', '~> 1.8'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -21,8 +21,8 @@ eos
 
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
-  gem.add_runtime_dependency 'google-api-client', '~> 0.9.0'
-  gem.add_runtime_dependency 'google-cloud-logging', '0.24.1'
+  gem.add_runtime_dependency 'google-api-client', '~> 0.14.5'
+  gem.add_runtime_dependency 'google-cloud-logging', '~> 1.2.3'
   gem.add_runtime_dependency 'googleauth', '~> 0.4', '< 0.5.2'
   gem.add_runtime_dependency 'grpc', '~> 1.0', '< 1.3'
   gem.add_runtime_dependency 'json', '~> 1.8'

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+require 'erb'
 require 'grpc'
 require 'json'
 require 'open-uri'
@@ -18,7 +19,7 @@ require 'socket'
 require 'time'
 require 'yaml'
 require 'google/apis'
-require 'google/apis/logging_v2beta1'
+require 'google/apis/logging_v2'
 require 'google/logging/v2/logging_pb'
 require 'google/logging/v2/logging_services_pb'
 require 'google/logging/v2/log_entry_pb'
@@ -144,7 +145,7 @@ module Fluent
           # The grpc version class name.
           'Google::Logging::Type::HttpRequest',
           # The non-grpc version class name.
-          'Google::Apis::LoggingV2beta1::HttpRequest'
+          'Google::Apis::LoggingV2::HttpRequest'
         ],
         'source_location' => [
           '@source_location_key',
@@ -154,7 +155,7 @@ module Fluent
             %w(line line parse_int)
           ],
           'Google::Logging::V2::LogEntrySourceLocation',
-          'Google::Apis::LoggingV2beta1::LogEntrySourceLocation'
+          'Google::Apis::LoggingV2::LogEntrySourceLocation'
         ],
         'operation' => [
           '@operation_key',
@@ -165,7 +166,7 @@ module Fluent
             %w(last last parse_bool)
           ],
           'Google::Logging::V2::LogEntryOperation',
-          'Google::Apis::LoggingV2beta1::LogEntryOperation'
+          'Google::Apis::LoggingV2::LogEntryOperation'
         ]
       }
     end
@@ -519,7 +520,7 @@ module Fluent
             # Remove the labels if we didn't populate them with anything.
             entry_level_resource.labels = nil if
               entry_level_resource.labels.empty?
-            entry = Google::Apis::LoggingV2beta1::LogEntry.new(
+            entry = Google::Apis::LoggingV2::LogEntry.new(
               labels: entry_level_common_labels,
               resource: entry_level_resource,
               severity: severity,
@@ -622,7 +623,7 @@ module Fluent
         else
           begin
             write_request = \
-              Google::Apis::LoggingV2beta1::WriteLogEntriesRequest.new(
+              Google::Apis::LoggingV2::WriteLogEntriesRequest.new(
                 log_name: log_name,
                 resource: group_level_resource,
                 labels: group_level_common_labels,
@@ -836,7 +837,7 @@ module Fluent
     # Metadata Agent. Thus it should be equivalent to what Metadata Agent
     # returns.
     def determine_agent_level_monitored_resource_via_legacy
-      resource = Google::Apis::LoggingV2beta1::MonitoredResource.new(
+      resource = Google::Apis::LoggingV2::MonitoredResource.new(
         labels: {})
       resource.type = determine_agent_level_monitored_resource_type
       resource.labels = determine_agent_level_monitored_resource_labels(
@@ -1187,7 +1188,7 @@ module Fluent
       # TODO(qingling128): Use Google::Api::MonitoredResource directly after we
       # upgrade gRPC version to include the fix for the protobuf map
       # corruption issue.
-      Google::Apis::LoggingV2beta1::MonitoredResource.new(
+      Google::Apis::LoggingV2::MonitoredResource.new(
         type: resource.type,
         labels: resource.labels.to_h
       )
@@ -1658,7 +1659,7 @@ module Fluent
       # TODO: Use a non-default ClientOptions object.
       Google::Apis::ClientOptions.default.application_name = PLUGIN_NAME
       Google::Apis::ClientOptions.default.application_version = PLUGIN_VERSION
-      @client = Google::Apis::LoggingV2beta1::LoggingService.new
+      @client = Google::Apis::LoggingV2::LoggingService.new
       @client.authorization = Google::Auth.get_application_default(
         LOGGING_SCOPE)
     end
@@ -1748,7 +1749,7 @@ end
 
 module Google
   module Apis
-    module LoggingV2beta1
+    module LoggingV2
       # Override MonitoredResource::dup to make a deep copy.
       class MonitoredResource
         def dup

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1023,11 +1023,11 @@ module BaseTest
       setup_logging_stubs do
         d = create_driver
         @logs_sent = []
-        d.emit('httpRequest' => HTTP_REQUEST_MESSAGE.merge('latency' => input))
+        d.emit('httpRequest' => http_request_message.merge('latency' => input))
         d.run
       end
       verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
-        assert_equal HTTP_REQUEST_MESSAGE.merge('latency' => expected),
+        assert_equal http_request_message.merge('latency' => expected),
                      entry['httpRequest'], entry
         assert_nil get_fields(entry['jsonPayload'])['httpRequest'], entry
       end
@@ -1044,11 +1044,11 @@ module BaseTest
       setup_logging_stubs do
         d = create_driver
         @logs_sent = []
-        d.emit('httpRequest' => HTTP_REQUEST_MESSAGE.merge('latency' => input))
+        d.emit('httpRequest' => http_request_message.merge('latency' => input))
         d.run
       end
       verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
-        assert_equal HTTP_REQUEST_MESSAGE, entry['httpRequest'], entry
+        assert_equal http_request_message, entry['httpRequest'], entry
         assert_nil get_fields(entry['jsonPayload'])['httpRequest'], entry
       end
     end
@@ -1597,8 +1597,22 @@ module BaseTest
     end
   end
 
+  def log_entry_subfields_params
+    {
+      # The keys are the names of fields in the payload that we are extracting
+      # LogEntry info from. The values are lists of two elements: the name of
+      # the subfield in LogEntry object and the expected value of that field.
+      DEFAULT_HTTP_REQUEST_KEY => [
+        'httpRequest', http_request_message],
+      DEFAULT_SOURCE_LOCATION_KEY => [
+        'sourceLocation', source_location_message],
+      DEFAULT_OPERATION_KEY => [
+        'operation', OPERATION_MESSAGE]
+    }
+  end
+
   def verify_subfields_from_record(payload_key)
-    destination_key, payload_value = LOG_ENTRY_SUBFIELDS_PARAMS[payload_key]
+    destination_key, payload_value = log_entry_subfields_params[payload_key]
     @logs_sent = []
     setup_gce_metadata_stubs
     setup_logging_stubs do
@@ -1614,7 +1628,7 @@ module BaseTest
   end
 
   def verify_subfields_partial_from_record(payload_key)
-    destination_key, payload_value = LOG_ENTRY_SUBFIELDS_PARAMS[payload_key]
+    destination_key, payload_value = log_entry_subfields_params[payload_key]
     @logs_sent = []
     setup_gce_metadata_stubs
     setup_logging_stubs do
@@ -1631,7 +1645,7 @@ module BaseTest
   end
 
   def verify_subfields_when_not_hash(payload_key)
-    destination_key = LOG_ENTRY_SUBFIELDS_PARAMS[payload_key][0]
+    destination_key = log_entry_subfields_params[payload_key][0]
     @logs_sent = []
     setup_gce_metadata_stubs
     setup_logging_stubs do
@@ -1646,14 +1660,22 @@ module BaseTest
     end
   end
 
+  def http_request_message
+    HTTP_REQUEST_MESSAGE
+  end
+
+  def source_location_message
+    SOURCE_LOCATION_MESSAGE
+  end
+
   # Replace the 'referer' field with nil.
   def http_request_message_with_nil_referer
-    HTTP_REQUEST_MESSAGE.merge('referer' => nil)
+    http_request_message.merge('referer' => nil)
   end
 
   # Unset the 'referer' field.
   def http_request_message_with_absent_referer
-    HTTP_REQUEST_MESSAGE.reject do |k, _|
+    http_request_message.reject do |k, _|
       k == 'referer'
     end
   end

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -533,13 +533,6 @@ module Constants
     'last' => true
   }
 
-  LOG_ENTRY_SUBFIELDS_PARAMS = {
-    # payload key, destination key, payload value
-    DEFAULT_HTTP_REQUEST_KEY => ['httpRequest', HTTP_REQUEST_MESSAGE],
-    DEFAULT_SOURCE_LOCATION_KEY => ['sourceLocation', SOURCE_LOCATION_MESSAGE],
-    DEFAULT_OPERATION_KEY => ['operation', OPERATION_MESSAGE]
-  }
-
   CUSTOM_LABELS_MESSAGE = {
     'customKey' => 'value'
   }

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -251,7 +251,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   private
 
-  WRITE_LOG_ENTRIES_URI = 'https://logging.googleapis.com/v2beta1/entries:write'
+  WRITE_LOG_ENTRIES_URI = 'https://logging.googleapis.com/v2/entries:write'
 
   def rename_key(hash, old_key, new_key)
     hash.merge(new_key => hash[old_key]).reject { |k, _| k == old_key }
@@ -315,5 +315,21 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
   # The null value.
   def null_value
     nil
+  end
+
+  # 'responseSize' and 'requestSize' are Integers in the gRPC proto, yet Strings
+  # in REST API client.
+  def http_request_message
+    HTTP_REQUEST_MESSAGE.merge(
+      'responseSize' => HTTP_REQUEST_MESSAGE['responseSize'].to_s,
+      'requestSize' => HTTP_REQUEST_MESSAGE['requestSize'].to_s
+    )
+  end
+
+  # 'line' is an Integer in the gRPC proto, yet a String in the REST API client.
+  def source_location_message
+    SOURCE_LOCATION_MESSAGE.merge(
+      'line' => SOURCE_LOCATION_MESSAGE['line'].to_s
+    )
   end
 end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -319,10 +319,10 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   # 'responseSize' and 'requestSize' are Integers in the gRPC proto, yet Strings
   # in REST API client.
-  # TODO(qingling128): Address this accordingly once the following  question is
+  # TODO(qingling128): Address this accordingly once the following question is
   # answered: https://github.com/google/google-api-ruby-client/issues/619.
-  # If this discrepency is legit, add some comments to explain the reason.
-  # Otherwise once the discrepency is fixed, we need to upgrade to that version
+  # If this discrepancy is legit, add some comments to explain the reason.
+  # Otherwise once the discrepancy is fixed, we need to upgrade to that version
   # and change our tests accordingly.
   def http_request_message
     HTTP_REQUEST_MESSAGE.merge(

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -319,7 +319,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   # 'responseSize' and 'requestSize' are Integers in the gRPC proto, yet Strings
   # in REST API client.
-  # TODO(lingshi): Address this accordingly once the following  question is
+  # TODO(qingling128): Address this accordingly once the following  question is
   # answered: https://github.com/google/google-api-ruby-client/issues/619.
   # If this discrepency is legit, add some comments to explain the reason.
   # Otherwise once the discrepency is fixed, we need to upgrade to that version

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -319,6 +319,11 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   # 'responseSize' and 'requestSize' are Integers in the gRPC proto, yet Strings
   # in REST API client.
+  # TODO(lingshi): Address this accordingly once the following  question is
+  # answered: https://github.com/google/google-api-ruby-client/issues/619.
+  # If this discrepency is legit, add some comments to explain the reason.
+  # Otherwise once the discrepency is fixed, we need to upgrade to that version
+  # and change our tests accordingly.
   def http_request_message
     HTTP_REQUEST_MESSAGE.merge(
       'responseSize' => HTTP_REQUEST_MESSAGE['responseSize'].to_s,


### PR DESCRIPTION
These upgrades are required for the coming partial success support.

Changes in these upgrades that affect us:
- `erb` is no longer bundled in Ruby core as of Ruby 2.2, which is required by these new gems. So we have to require it explicitly instead.
- The types of the following fields have been changed from `integer` to `String`: `cache_fill_bytes`, `response_size` and `request_size` in `HttpRequest`, `line` in `SourceLocation`. So we had to change our tests accordingly. https://github.com/google/google-api-ruby-client/issues/619 is created to double check these changes are intended. It feels weird.