### PR TITLE
Fix common label extraction for Cloud ML and Dataflow.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1091,6 +1091,18 @@ module Fluent
         common_labels.delete("#{COMPUTE_CONSTANTS[:service]}/resource_name")
       end
 
+      # Cloud Dataflow and Cloud ML.
+      # These labels can be set via configuring 'labels'.
+      # Report them as monitored resource labels instead of common labels.
+      # e.g. "dataflow.googleapis.com/job_id" => "job_id"
+      [DATAFLOW_CONSTANTS, ML_CONSTANTS].each do |service_constants|
+        next unless resource.type == service_constants[:resource_type]
+        resource.labels.merge!(
+          delete_and_extract_labels(
+            common_labels, service_constants[:extra_common_labels]
+              .map { |l| ["#{service_constants[:service]}/#{l}", l] }.to_h))
+      end
+
       resource.freeze
       resource.labels.freeze
       common_labels.freeze

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -68,7 +68,7 @@ module Fluent
       DATAFLOW_CONSTANTS = {
         service: 'dataflow.googleapis.com',
         resource_type: 'dataflow_step',
-        extra_common_labels: %w(region job_name job_id step_id)
+        extra_resource_labels: %w(region job_name job_id step_id)
       }
       DATAPROC_CONSTANTS = {
         service: 'cluster.dataproc.googleapis.com',
@@ -82,7 +82,7 @@ module Fluent
       ML_CONSTANTS = {
         service: 'ml.googleapis.com',
         resource_type: 'ml_job',
-        extra_common_labels: %w(job_id task_name)
+        extra_resource_labels: %w(job_id task_name)
       }
 
       # The map between a subservice name and a resource type.
@@ -1092,14 +1092,14 @@ module Fluent
       end
 
       # Cloud Dataflow and Cloud ML.
-      # These labels can be set via configuring 'labels'.
+      # These labels can be set via the 'labels' option.
       # Report them as monitored resource labels instead of common labels.
       # e.g. "dataflow.googleapis.com/job_id" => "job_id"
       [DATAFLOW_CONSTANTS, ML_CONSTANTS].each do |service_constants|
         next unless resource.type == service_constants[:resource_type]
         resource.labels.merge!(
           delete_and_extract_labels(
-            common_labels, service_constants[:extra_common_labels]
+            common_labels, service_constants[:extra_resource_labels]
               .map { |l| ["#{service_constants[:service]}/#{l}", l] }.to_h))
       end
 
@@ -1170,14 +1170,14 @@ module Fluent
       common_labels.merge!(delete_and_extract_labels(record, @label_map))
 
       # Cloud Dataflow and Cloud ML.
-      # These labels can be set via configuring 'labels' or 'label_map'.
+      # These labels can be set via the 'labels' or 'label_map' options.
       # Report them as monitored resource labels instead of common labels.
       # e.g. "dataflow.googleapis.com/job_id" => "job_id"
       [DATAFLOW_CONSTANTS, ML_CONSTANTS].each do |service_constants|
         next unless resource.type == service_constants[:resource_type]
         resource.labels.merge!(
           delete_and_extract_labels(
-            common_labels, service_constants[:extra_common_labels]
+            common_labels, service_constants[:extra_resource_labels]
               .map { |l| ["#{service_constants[:service]}/#{l}", l] }.to_h))
       end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -961,6 +961,26 @@ module BaseTest
     verify_log_entries(1, DATAPROC_PARAMS, 'jsonPayload')
   end
 
+  def test_cloud_ml_log
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver(CONFIG_ML, ML_TAG)
+      d.emit(ml_log_entry(0))
+      d.run
+    end
+    verify_log_entries(1, ML_PARAMS)
+  end
+
+  def test_cloud_dataflow_log
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver(CONFIG_DATAFLOW, DATAFLOW_TAG)
+      d.emit(dataflow_log_entry(0))
+      d.run
+    end
+    verify_log_entries(1, DATAFLOW_PARAMS)
+  end
+
   def test_log_entry_http_request_field_from_record
     verify_subfields_from_record(DEFAULT_HTTP_REQUEST_KEY)
   end

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -97,7 +97,7 @@ module Constants
   DATAFLOW_JOB_NAME = 'job_name_1'
   DATAFLOW_JOB_ID = 'job_id_1'
   DATAFLOW_STEP_ID = 'step_1'
-  DATAFLOW_TAG = 'dataflow.googleapis.com/worker'
+  DATAFLOW_TAG = 'dataflow-worker'
 
   # Dataproc specific labels.
   DATAPROC_CLUSTER_NAME = 'test-cluster'


### PR DESCRIPTION
Turned out that we never had Cloud ML and CLoud Dataflow tests.

The constants were added during the Logging API V2 Migration: https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/110/commits/6eebbc8cb5ff5c632b6e6e688f8db32e7ac1a0e6.

Yet there are no actual tests.

The root cause for the issue is that we should extract certain labels from `common metadata labels` to `resource labels` at the group level. (Previously we only did it at the entry level).