### PR TITLE
Remove gRPC version pin.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -24,7 +24,7 @@ eos
   gem.add_runtime_dependency 'google-api-client', '~> 0.14'
   gem.add_runtime_dependency 'google-cloud-logging', '~> 1.2', '>= 1.2.3'
   gem.add_runtime_dependency 'googleauth', '~> 0.4', '< 0.5.2'
-  gem.add_runtime_dependency 'grpc', '~> 1.0', '< 1.3'
+  gem.add_runtime_dependency 'grpc', '~> 1.0'
   gem.add_runtime_dependency 'json', '~> 1.8'
 
   gem.add_development_dependency 'mocha', '~> 1.1'

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -212,8 +212,13 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     use_grpc true
   )
 
+  @@mock_port = 0 # rubocop:disable Style/ClassVars
+
   def generate_mock_host
-    "localhost:#{Random.new.rand(50_000..60_000)}"
+    # rubocop:disable Style/ClassVars
+    @@mock_port = (@@mock_port + 1) % 10_000 + 50_000
+    "localhost:#{@@mock_port}"
+    # rubocop:enable Style/ClassVars
   end
 
   # Create a Fluentd output test driver with the Google Cloud Output plugin with
@@ -319,6 +324,10 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
   end
 
   # Set up grpc stubs to mock the external calls.
+  # TODO(qingling128): Remove this comment after grpc/12506 is resolved.
+  # Due to a gRPC load balancing issue (grpc/12506), we have to use a different
+  # port each time we create a gRPC mock as a temporary workaround. Thus we can
+  # only create one driver in each of setup_logging_stubs context.
   def setup_logging_stubs(should_fail = false, code = 0, message = 'Ok')
     # Save the mock host in an instance variable, so later on when creating the
     # logging driver, we can refer to this host with exactly the same port.

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -91,8 +91,8 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       [true, 13, 1, 2, [0, 1, 0, 0, 2]]
     ].each do |should_fail, code, request_count, entry_count, metric_values|
       setup_prometheus
-      setup_logging_stubs(should_fail, code, 'SomeMessage') do
-        (1..request_count).each do
+      (1..request_count).each do
+        setup_logging_stubs(should_fail, code, 'SomeMessage') do
           d = create_driver(USE_GRPC_CONFIG + PROMETHEUS_ENABLE_CONFIG, 'test',
                             GRPCLoggingMockFailingService.rpc_stub_class)
           (1..entry_count).each do |i|
@@ -205,8 +205,6 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
 
   private
 
-  GRPC_MOCK_HOST = 'localhost:56789'
-
   WriteLogEntriesRequest = Google::Logging::V2::WriteLogEntriesRequest
   WriteLogEntriesResponse = Google::Logging::V2::WriteLogEntriesResponse
 
@@ -214,22 +212,34 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     use_grpc true
   )
 
+  def generate_mock_host
+    "localhost:#{Random.new.rand(1_000..9_999)}"
+  end
+
   # Create a Fluentd output test driver with the Google Cloud Output plugin with
   # grpc enabled. The signature of this method is different between the grpc
   # path and the non-grpc path. For grpc, an additional grpc stub class can be
   # passed in to construct the mock used by the test driver.
   def create_driver(conf = APPLICATION_DEFAULT_CONFIG, tag = 'test',
                     grpc_stub = GRPCLoggingMockService.rpc_stub_class)
+    if @mock_host
+      mock_host = @mock_host
+      @mock_host = nil
+    else
+      mock_host = generate_mock_host
+    end
     conf += USE_GRPC_CONFIG
     Fluent::Test::BufferedOutputTestDriver.new(
-      GoogleCloudOutputWithGRPCMock.new(grpc_stub), tag).configure(conf, true)
+      GoogleCloudOutputWithGRPCMock.new(grpc_stub, mock_host),
+      tag).configure(conf, true)
   end
 
   # Google Cloud Fluent output stub with grpc mock.
   class GoogleCloudOutputWithGRPCMock < Fluent::GoogleCloudOutput
-    def initialize(grpc_stub)
+    def initialize(grpc_stub, mock_host)
       super()
       @grpc_stub = grpc_stub
+      @mock_host = mock_host
     end
 
     def api_client
@@ -240,7 +250,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
 
       # Here we have obtained the creds, but for the mock, we will leave the
       # channel insecure.
-      @grpc_stub.new(GRPC_MOCK_HOST, :this_channel_is_insecure)
+      @grpc_stub.new(@mock_host, :this_channel_is_insecure)
     end
   end
 
@@ -310,6 +320,9 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
 
   # Set up grpc stubs to mock the external calls.
   def setup_logging_stubs(should_fail = false, code = 0, message = 'Ok')
+    # Save the mock host in an instance variable, so later on when creating the
+    # logging driver, we can refer to this host with exactly the same port.
+    @mock_host = generate_mock_host
     srv = GRPC::RpcServer.new
     @failed_attempts = []
     @requests_sent = []
@@ -319,7 +332,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       grpc = GRPCLoggingMockService.new(@requests_sent)
     end
     srv.handle(grpc)
-    srv.add_http2_port(GRPC_MOCK_HOST, :this_port_is_insecure)
+    srv.add_http2_port(@mock_host, :this_port_is_insecure)
     t = Thread.new { srv.run }
     srv.wait_till_running
     begin
@@ -331,6 +344,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     end
     srv.stop
     t.join
+    @mock_host = nil
   end
 
   # Verify the number and the content of the log entries match the expectation.

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -231,6 +231,9 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       mock_host = @mock_host
       @mock_host = nil
     else
+      # @mock_host only gets set up when setup_logging_stubs is called. Some
+      # tests create drivers without creating a logging stub context. For these
+      # cases just use a new mock port.
       mock_host = generate_mock_host
     end
     conf += USE_GRPC_CONFIG

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -213,7 +213,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
   )
 
   def generate_mock_host
-    "localhost:#{Random.new.rand(1_000..9_999)}"
+    "localhost:#{Random.new.rand(50_000..60_000)}"
   end
 
   # Create a Fluentd output test driver with the Google Cloud Output plugin with

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -347,6 +347,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     end
     srv.stop
     t.join
+    @mock_host = nil
   end
 
   # Verify the number and the content of the log entries match the expectation.

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -227,18 +227,9 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
   # passed in to construct the mock used by the test driver.
   def create_driver(conf = APPLICATION_DEFAULT_CONFIG, tag = 'test',
                     grpc_stub = GRPCLoggingMockService.rpc_stub_class)
-    if @mock_host
-      mock_host = @mock_host
-      @mock_host = nil
-    else
-      # @mock_host only gets set up when setup_logging_stubs is called. Some
-      # tests create drivers without creating a logging stub context. For these
-      # cases just use a new mock port.
-      mock_host = generate_mock_host
-    end
     conf += USE_GRPC_CONFIG
     Fluent::Test::BufferedOutputTestDriver.new(
-      GoogleCloudOutputWithGRPCMock.new(grpc_stub, mock_host),
+      GoogleCloudOutputWithGRPCMock.new(grpc_stub, @mock_host),
       tag).configure(conf, true)
   end
 
@@ -356,7 +347,6 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     end
     srv.stop
     t.join
-    @mock_host = nil
   end
 
   # Verify the number and the content of the log entries match the expectation.

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -324,10 +324,10 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
   end
 
   # Set up grpc stubs to mock the external calls.
-  # TODO(qingling128): Remove this comment after grpc/12506 is resolved.
-  # Due to a gRPC load balancing issue (grpc/12506), we have to use a different
-  # port each time we create a gRPC mock as a temporary workaround. Thus we can
-  # only create one driver in each of setup_logging_stubs context.
+  # TODO(qingling128): Remove this comment after grpc/grpc#12506 is resolved.
+  # Due to a gRPC load balancing issue (grpc/grpc#12506), we have to use a
+  # different port each time we create a gRPC mock as a temporary workaround.
+  # Thus we can only create one driver in each setup_logging_stubs context.
   def setup_logging_stubs(should_fail = false, code = 0, message = 'Ok')
     # Save the mock host in an instance variable, so later on when creating the
     # logging driver, we can refer to this host with exactly the same port.


### PR DESCRIPTION
There is an open load balancing bug with `gRPC` at https://github.com/grpc/grpc/issues/12506.

Previously we use the same port for all mocks in our test, which triggers a ton of `Call dropped by load balancing policy` errors.

The short term workaround would be to use a different port for each test run. I've tested this change on a GCP VM. It seems to work fine. All logs are ingested. No errors in the Fluentd log.

The issue is still a bit concerning. Yet at least we can start the developing work for partial success which requires `gRPC` `1.6.6`.