### PR TITLE
Remove googleauth version pin.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -23,7 +23,7 @@ eos
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
   gem.add_runtime_dependency 'google-api-client', '~> 0.14'
   gem.add_runtime_dependency 'google-cloud-logging', '~> 1.2', '>= 1.2.3'
-  gem.add_runtime_dependency 'googleauth', '~> 0.4', '< 0.5.2'
+  gem.add_runtime_dependency 'googleauth', '~> 0.6'
   gem.add_runtime_dependency 'grpc', '~> 1.0'
   gem.add_runtime_dependency 'json', '~> 1.8'
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1357,14 +1357,14 @@ module BaseTest
 
   def setup_auth_stubs
     # Used when loading credentials from a JSON file.
-    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token')
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token')
       .with(body: hash_including(grant_type: AUTH_GRANT_TYPE))
       .to_return(body: %({"access_token": "#{FAKE_AUTH_TOKEN}"}),
                  status: 200,
                  headers: { 'Content-Length' => FAKE_AUTH_TOKEN.length,
                             'Content-Type' => 'application/json' })
 
-    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token')
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token')
       .with(body: hash_including(grant_type: 'refresh_token'))
       .to_return(body: %({"access_token": "#{FAKE_AUTH_TOKEN}"}),
                  status: 200,


### PR DESCRIPTION
The latest released `google-cloud-logging` gem requires `googleauth` to be > 0.6.1. Our pin conflicts with that. The original bug that triggered us to pin it < `0.5.2`has been fixed, so it should be fine for us to upgrade.