### PR TITLE
Request the logging scope from signet when fetching an access token.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1714,8 +1714,11 @@ module Fluent
     def api_client
       if @use_grpc
         ssl_creds = GRPC::Core::ChannelCredentials.new
-        authentication = Google::Auth.get_application_default
-        creds = GRPC::Core::CallCredentials.new(authentication.updater_proc)
+        authentication = Google::Auth.get_application_default(LOGGING_SCOPE)
+        updater_proc = lambda do |a_hash|
+          authentication.apply(a_hash, use_configured_scope: true)
+        end
+        creds = GRPC::Core::CallCredentials.new(updater_proc)
         creds = ssl_creds.compose(creds)
         @client = Google::Logging::V2::LoggingServiceV2::Stub.new(
           'logging.googleapis.com', creds)

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1722,7 +1722,8 @@ module Fluent
       else
         unless @client.authorization.expired?
           begin
-            @client.authorization.fetch_access_token!
+            @client.authorization.fetch_access_token!(
+              use_configured_scope: true)
           rescue MultiJson::ParseError
             # Workaround an issue in the API client; just re-raise a more
             # descriptive error for the user (which will still cause a retry).

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1715,10 +1715,9 @@ module Fluent
       if @use_grpc
         ssl_creds = GRPC::Core::ChannelCredentials.new
         authentication = Google::Auth.get_application_default(LOGGING_SCOPE)
-        updater_proc = lambda do |a_hash|
+        creds = GRPC::Core::CallCredentials.new(lambda do |a_hash|
           authentication.apply(a_hash, use_configured_scope: true)
-        end
-        creds = GRPC::Core::CallCredentials.new(updater_proc)
+        end)
         creds = ssl_creds.compose(creds)
         @client = Google::Logging::V2::LoggingServiceV2::Stub.new(
           'logging.googleapis.com', creds)

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -243,8 +243,10 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
 
     def api_client
       ssl_creds = GRPC::Core::ChannelCredentials.new
-      authentication = Google::Auth.get_application_default
-      creds = GRPC::Core::CallCredentials.new(authentication.updater_proc)
+      authentication = Google::Auth.get_application_default(LOGGING_SCOPE)
+      creds = GRPC::Core::CallCredentials.new(lambda do |a_hash|
+        authentication.apply(a_hash, use_configured_scope: true)
+      end)
       ssl_creds.compose(creds)
 
       # Here we have obtained the creds, but for the mock, we will leave the


### PR DESCRIPTION
The plugin already sets the logging scope to be requested for newly
acquired access token. However signet ignores this unless it obtains the
refresh token itself. google-fluentd usually uses a service account to
do so. If someone passes in an already created refresh token using the
GOOGLE_REFRESH_TOKEN environment variable, the access token request will
not request the logging scope. This fixes the latter.

More context about the change in signet (0.8+) can be found in
https://github.com/google/signet/pull/89