### PR TITLE
Add spanId field support, bump google-api-client version to 0.17 and google-cloud-logging version to 1.3.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -21,8 +21,8 @@ eos
 
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
-  gem.add_runtime_dependency 'google-api-client', '~> 0.14'
-  gem.add_runtime_dependency 'google-cloud-logging', '~> 1.2', '>= 1.2.3'
+  gem.add_runtime_dependency 'google-api-client', '~> 0.17'
+  gem.add_runtime_dependency 'google-cloud-logging', '~> 1.3', '>= 1.3.2'
   gem.add_runtime_dependency 'googleauth', '~> 0.6'
   gem.add_runtime_dependency 'grpc', '~> 1.0'
   gem.add_runtime_dependency 'json', '~> 1.8'

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -118,6 +118,7 @@ module Fluent
       DEFAULT_SOURCE_LOCATION_KEY =
         'logging.googleapis.com/sourceLocation'.freeze
       DEFAULT_TRACE_KEY = 'logging.googleapis.com/trace'.freeze
+      DEFAULT_SPAN_ID_KEY = 'logging.googleapis.com/spanId'.freeze
 
       DEFAULT_METADATA_AGENT_URL =
         'http://local-metadata-agent.stackdriver.com:8000'.freeze
@@ -230,6 +231,7 @@ module Fluent
     config_param :source_location_key, :string, :default =>
       DEFAULT_SOURCE_LOCATION_KEY
     config_param :trace_key, :string, :default => DEFAULT_TRACE_KEY
+    config_param :span_id_key, :string, :default => DEFAULT_SPAN_ID_KEY
 
     # Whether to try to detect if the record is a text log entry with JSON
     # content that needs to be parsed.
@@ -563,6 +565,9 @@ module Fluent
           # Get fully-qualified trace id for LogEntry "trace" field.
           fq_trace_id = record.delete(@trace_key)
           entry.trace = fq_trace_id if fq_trace_id
+
+          span_id = record.delete(@span_id_key)
+          entry.span_id = span_id if span_id
 
           set_log_entry_fields(record, entry)
           set_payload(entry_level_resource.type, record, entry, is_json)

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1089,15 +1089,15 @@ module BaseTest
   end
 
   def test_log_entry_trace_field
-    verify_log_entry_field_key('trace', DEFAULT_TRACE_KEY,
-                               'custom_trace_key',
-                               CONFIG_CUSTOM_TRACE_KEY_SPECIFIED)
+    sample_value = 'projects/project-1/traces/1234567890abcdef1234567890abcdef'
+    verify_field_key('trace', DEFAULT_TRACE_KEY, 'custom_trace_key',
+                     CONFIG_CUSTOM_TRACE_KEY_SPECIFIED, sample_value)
   end
 
   def test_log_entry_span_id_field
-    verify_log_entry_field_key('spanId', DEFAULT_SPAN_ID_KEY,
-                               'custom_span_id_key',
-                               CONFIG_CUSTOM_SPAN_ID_KEY_SPECIFIED)
+    sample_value = '000000000000004a'
+    verify_field_key('spanId', DEFAULT_SPAN_ID_KEY, 'custom_span_id_key',
+                     CONFIG_CUSTOM_SPAN_ID_KEY_SPECIFIED, sample_value)
   end
 
   # Metadata Agent related tests.
@@ -1654,11 +1654,10 @@ module BaseTest
     end
   end
 
-  def verify_log_entry_field_key(log_entry_field, default_key, custom_key,
-                                 custom_key_config)
+  def verify_field_key(log_entry_field, default_key, custom_key,
+                       custom_key_config, sample_value)
     setup_gce_metadata_stubs
     message = log_entry(0)
-    sample_value = "sample #{log_entry_field} value"
     [
       {
         # It leaves log entry field nil if no keyed value sent.
@@ -1697,7 +1696,6 @@ module BaseTest
       end
       verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
         assert_equal input[:expected_field_value], entry[log_entry_field], input
-
         payload_fields = get_fields(entry['jsonPayload'])
         assert_equal input[:expected_payload].size, payload_fields.size, input
         payload_fields.each do |key, value|

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1089,15 +1089,14 @@ module BaseTest
   end
 
   def test_log_entry_trace_field
-    sample_value = 'projects/project-1/traces/1234567890abcdef1234567890abcdef'
     verify_field_key('trace', DEFAULT_TRACE_KEY, 'custom_trace_key',
-                     CONFIG_CUSTOM_TRACE_KEY_SPECIFIED, sample_value)
+                     CONFIG_CUSTOM_TRACE_KEY_SPECIFIED,
+                     'projects/proj1/traces/1234567890abcdef1234567890abcdef')
   end
 
   def test_log_entry_span_id_field
-    sample_value = '000000000000004a'
     verify_field_key('spanId', DEFAULT_SPAN_ID_KEY, 'custom_span_id_key',
-                     CONFIG_CUSTOM_SPAN_ID_KEY_SPECIFIED, sample_value)
+                     CONFIG_CUSTOM_SPAN_ID_KEY_SPECIFIED, '000000000000004a')
   end
 
   # Metadata Agent related tests.

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -240,6 +240,10 @@ module Constants
     trace_key custom_trace_key
   ).freeze
 
+  CONFIG_CUSTOM_SPAN_ID_KEY_SPECIFIED = %(
+    span_id_key custom_span_id_key
+  ).freeze
+
   # Service configurations for various services.
 
   # GCE.


### PR DESCRIPTION
This will enable logging agent users to associate log entries with particular trace spans.

This requires an update of `google-api-client` and `google-cloud-logging` to support the new spanId field for the REST and gRPC call paths (See https://github.com/google/google-api-ruby-client/commit/35a23f126cde4723059b57954e90db4cf50ce7e9 and https://github.com/GoogleCloudPlatform/google-cloud-ruby/commit/48464a68fcdcc68fdd57a4872be2c02588b789dd).