### PR TITLE
Handle non-string severity values in the incoming JSON.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1454,7 +1454,7 @@ module Fluent
 
     def parse_severity(severity_str)
       # The API is case insensitive, but uppercase to make things simpler.
-      severity = severity_str.upcase.strip
+      severity = severity_str.to_s.upcase.strip
 
       # If the severity is already valid, just return it.
       return severity if VALID_SEVERITIES.include?(severity)

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -206,6 +206,8 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     assert_equal(100, test_obj.parse_severity('     105'))
     assert_equal(100, test_obj.parse_severity('     105    '))
 
+    assert_equal(100, test_obj.parse_severity(100))
+
     assert_equal('DEFAULT', test_obj.parse_severity('-100'))
     assert_equal('DEFAULT', test_obj.parse_severity('105 100'))
 
@@ -243,6 +245,11 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     assert_equal('DEFAULT', test_obj.parse_severity('ER ROR'))
 
     # anything else should translate to 'DEFAULT'
+    assert_equal('DEFAULT', test_obj.parse_severity(nil))
+    assert_equal('DEFAULT', test_obj.parse_severity(Object.new))
+    assert_equal('DEFAULT', test_obj.parse_severity({}))
+    assert_equal('DEFAULT', test_obj.parse_severity([]))
+    assert_equal('DEFAULT', test_obj.parse_severity(100.0))
     assert_equal('DEFAULT', test_obj.parse_severity(''))
     assert_equal('DEFAULT', test_obj.parse_severity('garbage'))
     assert_equal('DEFAULT', test_obj.parse_severity('er'))


### PR DESCRIPTION
Fixes #169.