### PR TITLE
Prefer the project id from the credentials file.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -839,11 +839,9 @@ module Fluent
     # 2. If not, try to retrieve it by calling metadata server directly.
     # 3. If still not set, try to obtain it from the credentials.
     def set_project_id
+      @project_id ||= CredentialsInfo.project_id
       @project_id ||= fetch_gce_metadata('project/project-id') if
         @platform == Platform::GCE
-      @project_id ||= CredentialsInfo.project_id
-    rescue StandardError => e
-      @log.error 'Failed to obtain project id: ', error: e
     end
 
     # 1. Return the value if it is explicitly set in the config already.

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -188,8 +188,8 @@ module BaseTest
   end
 
   def test_project_id_from_credentials
-    %w(gce_metadata ec2_metadata no_metadata_service).each do |platform|
-      send("setup_#{platform}_stubs")
+    %w(gce ec2).each do |platform|
+      send("setup_#{platform}_metadata_stubs")
       [IAM_CREDENTIALS, LEGACY_CREDENTIALS].each do |creds|
         ENV['GOOGLE_APPLICATION_CREDENTIALS'] = creds[:path]
         d = create_driver


### PR DESCRIPTION
Also fix/expand invalid credentials file tests.