### PR TITLE
Add grpc and status code info in request and entry count metrics.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -393,7 +393,7 @@ module Fluent
           'The number of log entries that failed to be ingested by the'\
             ' Stackdriver output plugin due to a transient error and were'\
             ' retried')
-        @ok_code = @use_grpc ? 0 : 200
+        @ok_code = if @use_grpc then 0 else 200 end
       end
 
       # Alert on old authentication configuration.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -393,7 +393,6 @@ module Fluent
           'The number of log entries that failed to be ingested by the'\
             ' Stackdriver output plugin due to a transient error and were'\
             ' retried')
-        @ok_code = if @use_grpc then 0 else 200 end
       end
 
       # Alert on old authentication configuration.
@@ -1877,7 +1876,7 @@ module Fluent
     # Increment the metric for the number of successful requests.
     def increment_successful_requests_count
       return unless @successful_requests_count
-      @successful_requests_count.increment(grpc: @use_grpc, code: @ok_code)
+      @successful_requests_count.increment(grpc: @use_grpc)
     end
 
     # Increment the metric for the number of failed requests, labeled by
@@ -1891,8 +1890,7 @@ module Fluent
     # ingested by the Stackdriver Logging API.
     def increment_ingested_entries_count(count)
       return unless @ingested_entries_count
-      @ingested_entries_count.increment({ grpc: @use_grpc, code: @ok_code },
-                                        count)
+      @ingested_entries_count.increment({ grpc: @use_grpc }, count)
     end
 
     # Increment the metric for the number of log entries that were dropped

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -393,7 +393,7 @@ module Fluent
           'The number of log entries that failed to be ingested by the'\
             ' Stackdriver output plugin due to a transient error and were'\
             ' retried')
-        @ok_code = if @use_grpc then 0 else 200 end
+        @ok_code = @use_grpc ? 0 : 200
       end
 
       # Alert on old authentication configuration.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -393,6 +393,7 @@ module Fluent
           'The number of log entries that failed to be ingested by the'\
             ' Stackdriver output plugin due to a transient error and were'\
             ' retried')
+        @ok_code = @use_grpc ? 0 : 200
       end
 
       # Alert on old authentication configuration.
@@ -1876,7 +1877,7 @@ module Fluent
     # Increment the metric for the number of successful requests.
     def increment_successful_requests_count
       return unless @successful_requests_count
-      @successful_requests_count.increment(grpc: @use_grpc)
+      @successful_requests_count.increment(grpc: @use_grpc, code: @ok_code)
     end
 
     # Increment the metric for the number of failed requests, labeled by
@@ -1890,7 +1891,8 @@ module Fluent
     # ingested by the Stackdriver Logging API.
     def increment_ingested_entries_count(count)
       return unless @ingested_entries_count
-      @ingested_entries_count.increment({ grpc: @use_grpc }, count)
+      @ingested_entries_count.increment({ grpc: @use_grpc, code: @ok_code },
+                                        count)
     end
 
     # Increment the metric for the number of log entries that were dropped

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -632,17 +632,15 @@ module Fluent
               @log.debug "Retrying #{entries_count} log message(s) later.",
                          error: error.to_s, error_code: error.code.to_s
               raise error
-            when GRPC::Core::StatusCodes::UNIMPLEMENTED,
-                 GRPC::Core::StatusCodes::RESOURCE_EXHAUSTED
-              # Most client errors indicate a problem with the request itself
-              # and should not be retried.
-              increment_dropped_entries_count(entries_count, error.code)
-              @log.warn "Dropping #{entries_count} log message(s)",
-                        error: error.to_s, error_code: error.code.to_s
-            when GRPC::Core::StatusCodes::UNAUTHENTICATED
-              # Authorization error.
-              # These are usually solved via a `gcloud auth` call, or by
-              # modifying the permissions on the Google Cloud project.
+            when \
+                # Most client errors indicate a problem with the request itself
+                # and should not be retried.
+                GRPC::Core::StatusCodes::UNIMPLEMENTED,
+                GRPC::Core::StatusCodes::RESOURCE_EXHAUSTED,
+                # Authorization error.
+                # These are usually solved via a `gcloud auth` call, or by
+                # modifying the permissions on the Google Cloud project.
+                GRPC::Core::StatusCodes::UNAUTHENTICATED
               increment_dropped_entries_count(entries_count, error.code)
               @log.warn "Dropping #{entries_count} log message(s)",
                         error: error.to_s, error_code: error.code.to_s

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -635,20 +635,20 @@ module Fluent
                  GRPC::Core::StatusCodes::RESOURCE_EXHAUSTED
               # Most client errors indicate a problem with the request itself
               # and should not be retried.
-              increment_dropped_entries_count(entries_count)
+              increment_dropped_entries_count(entries_count, error.code)
               @log.warn "Dropping #{entries_count} log message(s)",
                         error: error.to_s, error_code: error.code.to_s
             when GRPC::Core::StatusCodes::UNAUTHENTICATED
               # Authorization error.
               # These are usually solved via a `gcloud auth` call, or by
               # modifying the permissions on the Google Cloud project.
-              increment_dropped_entries_count(entries_count)
+              increment_dropped_entries_count(entries_count, error.code)
               @log.warn "Dropping #{entries_count} log message(s)",
                         error: error.to_s, error_code: error.code.to_s
             else
               # Assume this is a problem with the request itself and don't
               # retry.
-              increment_dropped_entries_count(entries_count)
+              increment_dropped_entries_count(entries_count, error.code)
               @log.error "Unknown response code #{error.code} from the "\
                          "server, dropping #{entries_count} log message(s)",
                          error: error.to_s, error_code: error.code.to_s
@@ -696,7 +696,7 @@ module Fluent
             # Authorization error.
             # These are usually solved via a `gcloud auth` call, or by modifying
             # the permissions on the Google Cloud project.
-            increment_dropped_entries_count(entries_count)
+            increment_dropped_entries_count(entries_count, error.status_code)
             @log.warn "Dropping #{entries_count} log message(s)",
                       error_class: error.class.to_s, error: error.to_s
 
@@ -705,13 +705,13 @@ module Fluent
             # should not be retried.
             error_details_map = construct_error_details_map(error)
             if error_details_map.empty?
-              increment_dropped_entries_count(entries_count)
+              increment_dropped_entries_count(entries_count, error.status_code)
               @log.warn "Dropping #{entries_count} log message(s)",
                         error_class: error.class.to_s, error: error.to_s
             else
               error_details_map.each do |(error_code, error_message), indexes|
                 partial_error_count = indexes.length
-                increment_dropped_entries_count(partial_error_count)
+                increment_dropped_entries_count(partial_error_count, error_code)
                 @log.warn "Dropping #{partial_error_count} log message(s)",
                           error_code: "google.rpc.Code[#{error_code}]",
                           error: error_message
@@ -1892,21 +1892,21 @@ module Fluent
     # ingested by the Stackdriver Logging API.
     def increment_ingested_entries_count(count)
       return unless @ingested_entries_count
-      @ingested_entries_count.increment({}, count)
+      @ingested_entries_count.increment({ grpc: @use_grpc }, count)
     end
 
     # Increment the metric for the number of log entries that were dropped
     # and not ingested by the Stackdriver Logging API.
-    def increment_dropped_entries_count(count)
+    def increment_dropped_entries_count(count, code)
       return unless @dropped_entries_count
-      @dropped_entries_count.increment({}, count)
+      @dropped_entries_count.increment({ grpc: @use_grpc, code: code }, count)
     end
 
     # Increment the metric for the number of log entries that were dropped
     # and not ingested by the Stackdriver Logging API.
     def increment_retried_entries_count(count, code)
       return unless @retried_entries_count
-      @retried_entries_count.increment({ code: code }, count)
+      @retried_entries_count.increment({ grpc: @use_grpc, code: code }, count)
     end
   end
 end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -393,6 +393,7 @@ module Fluent
           'The number of log entries that failed to be ingested by the'\
             ' Stackdriver output plugin due to a transient error and were'\
             ' retried')
+        @ok_code = if @use_grpc then 0 else 200 end
       end
 
       # Alert on old authentication configuration.
@@ -1878,7 +1879,7 @@ module Fluent
     # Increment the metric for the number of successful requests.
     def increment_successful_requests_count
       return unless @successful_requests_count
-      @successful_requests_count.increment(grpc: @use_grpc)
+      @successful_requests_count.increment(grpc: @use_grpc, code: @ok_code)
     end
 
     # Increment the metric for the number of failed requests, labeled by
@@ -1892,7 +1893,8 @@ module Fluent
     # ingested by the Stackdriver Logging API.
     def increment_ingested_entries_count(count)
       return unless @ingested_entries_count
-      @ingested_entries_count.increment({ grpc: @use_grpc }, count)
+      @ingested_entries_count.increment({ grpc: @use_grpc, code: @ok_code },
+                                        count)
     end
 
     # Increment the metric for the number of log entries that were dropped

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -648,5 +648,5 @@ module Constants
         }
       ]
     }
-  }.to_json
+  }.freeze
 end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -129,14 +129,12 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
         ingested_entries_count, dropped_entries_count,
         retried_entries_count = metric_values
       assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                     successful_requests_count,
-                                     grpc: false, code: 200)
+                                     successful_requests_count, grpc: false)
       assert_prometheus_metric_value(:stackdriver_failed_requests_count,
                                      failed_requests_count,
                                      grpc: false, code: code)
       assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                     ingested_entries_count,
-                                     grpc: false, code: 200)
+                                     ingested_entries_count, grpc: false)
       assert_prometheus_metric_value(:stackdriver_dropped_entries_count,
                                      dropped_entries_count,
                                      grpc: false, code: code)

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -129,12 +129,14 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
         ingested_entries_count, dropped_entries_count,
         retried_entries_count = metric_values
       assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                     successful_requests_count, grpc: false)
+                                     successful_requests_count,
+                                     grpc: false, code: 200)
       assert_prometheus_metric_value(:stackdriver_failed_requests_count,
                                      failed_requests_count,
                                      grpc: false, code: code)
       assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                     ingested_entries_count, grpc: false)
+                                     ingested_entries_count,
+                                     grpc: false, code: 200)
       assert_prometheus_metric_value(:stackdriver_dropped_entries_count,
                                      dropped_entries_count,
                                      grpc: false, code: code)

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -110,14 +110,12 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
         ingested_entries_count, dropped_entries_count,
         retried_entries_count = metric_values
       assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                     successful_requests_count,
-                                     grpc: true, code: 0)
+                                     successful_requests_count, grpc: true)
       assert_prometheus_metric_value(:stackdriver_failed_requests_count,
                                      failed_requests_count,
                                      grpc: true, code: code)
       assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                     ingested_entries_count,
-                                     grpc: true, code: 0)
+                                     ingested_entries_count, grpc: true)
       assert_prometheus_metric_value(:stackdriver_dropped_entries_count,
                                      dropped_entries_count,
                                      grpc: true, code: code)

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -115,11 +115,13 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
                                      failed_requests_count,
                                      grpc: true, code: code)
       assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                     ingested_entries_count)
+                                     ingested_entries_count, grpc: true)
       assert_prometheus_metric_value(:stackdriver_dropped_entries_count,
-                                     dropped_entries_count)
+                                     dropped_entries_count,
+                                     grpc: true, code: code)
       assert_prometheus_metric_value(:stackdriver_retried_entries_count,
-                                     retried_entries_count, code: code)
+                                     retried_entries_count,
+                                     grpc: true, code: code)
     end
   end
 

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -110,12 +110,14 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
         ingested_entries_count, dropped_entries_count,
         retried_entries_count = metric_values
       assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                     successful_requests_count, grpc: true)
+                                     successful_requests_count,
+                                     grpc: true, code: 0)
       assert_prometheus_metric_value(:stackdriver_failed_requests_count,
                                      failed_requests_count,
                                      grpc: true, code: code)
       assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                     ingested_entries_count, grpc: true)
+                                     ingested_entries_count,
+                                     grpc: true, code: 0)
       assert_prometheus_metric_value(:stackdriver_dropped_entries_count,
                                      dropped_entries_count,
                                      grpc: true, code: code)


### PR DESCRIPTION
For gRPC, the official 'OK' code (https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.Core/StatusCode.cs) is 0. Yet for our case, 'successful_requests_count' simply gets mapped as response_code=200 regardless.