### PR TITLE
Remove redundant GRPC::Cancelled case.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -600,14 +600,6 @@ module Fluent
               @log.info 'Successfully sent gRPC to Stackdriver Logging API.'
             end
 
-          rescue GRPC::Cancelled => error
-            increment_failed_requests_count(GRPC::Core::StatusCodes::CANCELLED)
-            increment_retried_entries_count(entries_count, error.code)
-            # RPC cancelled, so retry via re-raising the error.
-            @log.debug "Retrying #{entries_count} log message(s) later.",
-                       error: error.to_s, error_code: error.code.to_s
-            raise error
-
           rescue GRPC::BadStatus => error
             increment_failed_requests_count(error.code)
             case error.code

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -609,7 +609,7 @@ module Fluent
                  GRPC::Core::StatusCodes::INTERNAL,
                  GRPC::Core::StatusCodes::UNKNOWN
               # Server error, so retry via re-raising the error.
-              increment_retried_entries_count(entries.length, error.code)
+              increment_retried_entries_count(entries_count, error.code)
               @log.debug "Retrying #{entries_count} log message(s) later.",
                          error: error.to_s, error_code: error.code.to_s
               raise error
@@ -667,7 +667,7 @@ module Fluent
 
           rescue Google::Apis::ServerError => error
             # Server error, so retry via re-raising the error.
-            increment_retried_entries_count(entries.length, error.status_code)
+            increment_retried_entries_count(entries_count, error.status_code)
             @log.debug "Retrying #{entries_count} log message(s) later.",
                        error: error.to_s, error_code: error.status_code.to_s
             raise error


### PR DESCRIPTION
Per https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/errors.rb#L91, `GRPC::Cancelled` is a subclass of `GRPC::BadStatus`, thus already covered in the other case. Removing the redundant part.