### PR TITLE
Add a flag to control whether to group log tags when sending requests to Stackdriver Logging API.

### DIFF
--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -620,19 +620,19 @@ module BaseTest
   def test_split_logs_by_tag
     setup_gce_metadata_stubs
     log_entries_count = 5
-    dynamic_log_names = Array(0..log_entries_count - 1).map do |index|
+    dynamic_log_names = (0..log_entries_count - 1).map do |index|
       "projects/test-project-id/logs/tag#{index}"
     end
     [
       [APPLICATION_DEFAULT_CONFIG,
        log_entries_count,
        dynamic_log_names,
-       Array.new(log_entries_count, nil)],
+       Array.new(log_entries_count)],
       [DISABLE_SPLIT_LOGS_BY_TAG_CONFIG,
        1,
-       Array.new(log_entries_count, ''),
+       [''],
        dynamic_log_names]
-    ].each do |(config, requests_count, request_log_names, entry_log_names)|
+    ].each do |(config, request_count, request_log_names, entry_log_names)|
       setup_prometheus
       setup_logging_stubs do
         @logs_sent = []
@@ -641,24 +641,24 @@ module BaseTest
           d.emit("tag#{i}", 'message' => log_entry(i))
         end
         d.run
-        @logs_sent.each_with_index do |request, request_index|
-          assert_equal request_log_names[request_index], request['logName']
-        end
-        verify_log_entries(log_entries_count, COMPUTE_PARAMS_WITH_MULTI_TAGS,
-                           'textPayload') do |entry, entry_index|
-          verify_default_log_entry_text(entry['textPayload'], entry_index,
-                                        entry)
-          assert_equal entry_log_names[entry_index], entry['logName']
-        end
-        # Verify the number of requests is different based on whether the
-        # 'split_logs_by_tag' flag is enabled.
-        assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                       requests_count,
-                                       grpc: use_grpc, code: ok_status_code)
-        assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                       log_entries_count,
-                                       grpc: use_grpc, code: ok_status_code)
       end
+      @logs_sent.each_with_index do |request, request_index|
+        assert_equal request_log_names[request_index], request['logName']
+      end
+      verify_log_entries(log_entries_count, COMPUTE_PARAMS_WITH_MULTI_TAGS,
+                         'textPayload') do |entry, entry_index|
+        verify_default_log_entry_text(entry['textPayload'], entry_index,
+                                      entry)
+        assert_equal entry_log_names[entry_index], entry['logName']
+      end
+      # Verify the number of requests is different based on whether the
+      # 'split_logs_by_tag' flag is enabled.
+      assert_prometheus_metric_value(:stackdriver_successful_requests_count,
+                                     request_count,
+                                     grpc: use_grpc, code: ok_status_code)
+      assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
+                                     log_entries_count,
+                                     grpc: use_grpc, code: ok_status_code)
     end
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1647,8 +1647,7 @@ module BaseTest
   end
 
   # The caller can optionally provide a block which is called for each entry.
-  def verify_log_entries(n, params, payload_type = 'textPayload')
-    jsonify_log_entries
+  def verify_json_log_entries(n, params, payload_type = 'textPayload')
     entry_count = 0
     @logs_sent.each do |request|
       request['entries'].each do |entry|
@@ -1834,8 +1833,9 @@ module BaseTest
     _undefined
   end
 
-  # Jsonify the log entries response if it is not in JSON format.
-  def jsonify_log_entries
+  # Verify the number and the content of the log entries match the expectation.
+  # The caller can optionally provide a block which is called for each entry.
+  def verify_log_entries(_n, _params, _payload_type = 'textPayload', &_block)
     _undefined
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -649,9 +649,9 @@ module BaseTest
       # Verify the number of requests is different based on whether the
       # 'split_logs_by_tag' flag is enabled.
       assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                     request_count, :all)
+                                     request_count, :aggregate)
       assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                     log_entry_count, :all)
+                                     log_entry_count, :aggregate)
     end
   end
 
@@ -1837,7 +1837,7 @@ module BaseTest
   def assert_prometheus_metric_value(metric_name, expected_value, labels = {})
     metric = Prometheus::Client.registry.get(metric_name)
     assert_not_nil(metric)
-    metric_value = if labels == :all
+    metric_value = if labels == :aggregate
                      # Sum up all metric values regardless of the labels.
                      metric.values.values.reduce(0.0, :+)
                    else

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -649,9 +649,9 @@ module BaseTest
       # Verify the number of requests is different based on whether the
       # 'split_logs_by_tag' flag is enabled.
       assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                     request_count)
+                                     request_count, :all)
       assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                     log_entry_count)
+                                     log_entry_count, :all)
     end
   end
 
@@ -1834,13 +1834,14 @@ module BaseTest
     _undefined
   end
 
-  def assert_prometheus_metric_value(metric_name, expected_value, labels = nil)
+  def assert_prometheus_metric_value(metric_name, expected_value, labels = {})
     metric = Prometheus::Client.registry.get(metric_name)
     assert_not_nil(metric)
-    metric_value = if labels
-                     metric.get(labels)
-                   else
+    metric_value = if labels == :all
+                     # Sum up all metric values regardless of the labels.
                      metric.values.values.reduce(0.0, :+)
+                   else
+                     metric.get(labels)
                    end
     assert_equal(expected_value, metric_value)
   end

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -247,7 +247,7 @@ module Constants
   # Service configurations for various services.
 
   # GCE.
-  COMPUTE_PARAMS = {
+  COMPUTE_PARAMS_NO_LOG_NAME = {
     resource: {
       type: COMPUTE_CONSTANTS[:resource_type],
       labels: {
@@ -255,12 +255,14 @@ module Constants
         'zone' => ZONE
       }
     },
-    log_name: 'test',
     project_id: PROJECT_ID,
     labels: {
       "#{COMPUTE_CONSTANTS[:service]}/resource_name" => HOSTNAME
     }
   }.freeze
+  COMPUTE_PARAMS = COMPUTE_PARAMS_NO_LOG_NAME.merge(
+    log_name: 'test'
+  ).freeze
   COMPUTE_PARAMS_WITH_METADATA_VM_ID_AND_ZONE = COMPUTE_PARAMS.merge(
     resource: COMPUTE_PARAMS[:resource].merge(
       labels: {
@@ -269,8 +271,6 @@ module Constants
       }
     )
   ).freeze
-  COMPUTE_PARAMS_WITH_MULTI_TAGS =
-    COMPUTE_PARAMS.reject { |k, _| k == :log_name }.freeze
 
   # GAE.
   VMENGINE_PARAMS = {

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -166,6 +166,10 @@ module Constants
     detect_subservice false
   ).freeze
 
+  DISABLE_SPLIT_LOGS_BY_TAG_CONFIG = %(
+    split_logs_by_tag false
+  ).freeze
+
   PROMETHEUS_ENABLE_CONFIG = %(
     enable_monitoring true
     monitoring_type prometheus

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -269,6 +269,8 @@ module Constants
       }
     )
   ).freeze
+  COMPUTE_PARAMS_WITH_MULTI_TAGS =
+    COMPUTE_PARAMS.reject { |k, _| k == :log_name }.freeze
 
   # GAE.
   VMENGINE_PARAMS = {

--- a/test/plugin/test_driver.rb
+++ b/test/plugin/test_driver.rb
@@ -1,0 +1,55 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'fluent/engine'
+require 'fluent/event'
+require 'fluent/test/input_test'
+
+module Fluent
+  module Test
+    # Similar to the standard BufferedOutputTestDriver, but allows multiple tags
+    # to exist in one chunk.
+    class MultiTagBufferedOutputTestDriver < InputTestDriver
+      def initialize(klass, &block)
+        super(klass, &block)
+        @entries = []
+      end
+
+      def emit(tag, record, time = Engine.now)
+        es = ArrayEventStream.new([[time, record]])
+        data = @instance.format_stream(tag, es)
+        @entries << data
+        self
+      end
+
+      def run(num_waits = 10)
+        result = nil
+        super(num_waits) do
+          chunk = @instance.buffer.generate_chunk(
+            @instance.metadata(nil, nil, nil)).staged!
+          @entries.each do |entry|
+            chunk.concat(entry, 1)
+          end
+
+          begin
+            result = @instance.write(chunk)
+          ensure
+            chunk.purge
+          end
+        end
+        result
+      end
+    end
+  end
+end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -330,7 +330,10 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     driver.configure(conf, true)
   end
 
-  def jsonify_log_entries
+  # Verify the number and the content of the log entries match the expectation.
+  # The caller can optionally provide a block which is called for each entry.
+  def verify_log_entries(n, params, payload_type = 'textPayload', &block)
+    verify_json_log_entries(n, params, payload_type, &block)
   end
 
   # For an optional field with default values, Protobuf omits the field when it

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -308,14 +308,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     yield
   end
 
-  def use_grpc
-    false
-  end
-
-  def ok_status_code
-    200
-  end
-
   # Create a Fluentd output test driver with the Google Cloud Output plugin.
   def create_driver(conf = APPLICATION_DEFAULT_CONFIG,
                     tag = 'test',

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -156,29 +156,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     end
   end
 
-  def test_log_name_when_split_logs_by_tag_disabled
-    setup_gce_metadata_stubs
-    log_entries_count = 5
-    setup_prometheus
-    setup_logging_stubs do
-      d = create_driver(DISABLE_SPLIT_LOGS_BY_TAG_CONFIG +
-                        PROMETHEUS_ENABLE_CONFIG, 'test', true)
-      log_entries_count.times do |i|
-        d.emit("tag#{i}", 'message' => log_entry(0))
-      end
-      d.run
-      emit_index = 0
-      @logs_sent.each do |request_sent|
-        assert_equal '', request_sent['logName']
-        request_sent['entries'].each do |entry|
-          assert_equal "projects/test-project-id/logs/tag#{emit_index}",
-                       entry['logName']
-          emit_index += 1
-        end
-      end
-    end
-  end
-
   # This test looks similar between the grpc and non-grpc paths except that when
   # parsing "105", the grpc path responds with "DEBUG", while the non-grpc path
   # responds with "100".
@@ -353,10 +330,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     driver.configure(conf, true)
   end
 
-  # Verify the number and the content of the log entries match the expectation.
-  # The caller can optionally provide a block which is called for each entry.
-  def verify_log_entries(n, params, payload_type = 'textPayload', &block)
-    verify_json_log_entries(n, params, payload_type, &block)
+  def jsonify_log_entries
   end
 
   # For an optional field with default values, Protobuf omits the field when it

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -15,6 +15,7 @@
 require 'grpc'
 
 require_relative 'base_test'
+require_relative 'test_driver'
 
 # Unit tests for Google Cloud Logging plugin
 class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
@@ -130,6 +131,29 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     end
   end
 
+  def test_log_name_when_split_logs_by_tag_disabled
+    setup_gce_metadata_stubs
+    log_entries_count = 5
+    setup_prometheus
+    setup_logging_stubs do
+      d = create_driver(DISABLE_SPLIT_LOGS_BY_TAG_CONFIG +
+                        PROMETHEUS_ENABLE_CONFIG, 'test', true)
+      log_entries_count.times do |i|
+        d.emit("tag#{i}", 'message' => log_entry(0))
+      end
+      d.run
+    end
+    emit_index = 0
+    @requests_sent.each do |request_sent|
+      assert_equal '', request_sent.log_name
+      request_sent.entries.each do |entry|
+        assert_equal "projects/test-project-id/logs/tag#{emit_index}",
+                     entry.log_name
+        emit_index += 1
+      end
+    end
+  end
+
   # This test looks similar between the grpc and non-grpc paths except that when
   # parsing "105", the grpc path responds with "DEBUG", while the non-grpc path
   # responds with "100".
@@ -219,14 +243,30 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     use_grpc true
   ).freeze
 
+  def use_grpc
+    true
+  end
+
+  def ok_status_code
+    GRPC::Core::StatusCodes::OK
+  end
+
   # Create a Fluentd output test driver with the Google Cloud Output plugin with
   # grpc enabled. The signature of this method is different between the grpc
   # path and the non-grpc path. For grpc, an additional grpc stub class can be
   # passed in to construct the mock used by the test driver.
-  def create_driver(conf = APPLICATION_DEFAULT_CONFIG, tag = 'test')
+  def create_driver(conf = APPLICATION_DEFAULT_CONFIG,
+                    tag = 'test',
+                    multi_tags = false)
     conf += USE_GRPC_CONFIG
-    Fluent::Test::BufferedOutputTestDriver.new(
-      GoogleCloudOutputWithGRPCMock.new(@grpc_stub), tag).configure(conf, true)
+    driver = if multi_tags
+               Fluent::Test::MultiTagBufferedOutputTestDriver.new(
+                 GoogleCloudOutputWithGRPCMock.new(@grpc_stub))
+             else
+               Fluent::Test::BufferedOutputTestDriver.new(
+                 GoogleCloudOutputWithGRPCMock.new(@grpc_stub), tag)
+             end
+    driver.configure(conf, true)
   end
 
   # Google Cloud Fluent output stub with grpc mock.

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -319,7 +319,9 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     yield
   end
 
-  def jsonify_log_entries
+  # Verify the number and the content of the log entries match the expectation.
+  # The caller can optionally provide a block which is called for each entry.
+  def verify_log_entries(n, params, payload_type = 'textPayload', &block)
     @requests_sent.each do |request|
       @logs_sent << {
         'entries' => request.entries.map { |entry| JSON.parse(entry.to_json) },
@@ -328,6 +330,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
         'logName' => request.log_name
       }
     end
+    verify_json_log_entries(n, params, payload_type, &block)
   end
 
   # Use the right single quotation mark as the sample non-utf8 character.

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -220,14 +220,6 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     use_grpc true
   ).freeze
 
-  def use_grpc
-    true
-  end
-
-  def ok_status_code
-    GRPC::Core::StatusCodes::OK
-  end
-
   # Create a Fluentd output test driver with the Google Cloud Output plugin with
   # grpc enabled. The signature of this method is different between the grpc
   # path and the non-grpc path. For grpc, an additional grpc stub class can be


### PR DESCRIPTION
This depends on https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/201.