### PR TITLE
Restore #180 and remove google-cloud-logging and grpc pins.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -21,10 +21,10 @@ eos
 
   gem.add_runtime_dependency 'fluentd', '~> 0.10'
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
-  gem.add_runtime_dependency 'google-api-client', '~> 0.14'
-  gem.add_runtime_dependency 'google-cloud-logging', '~> 1.2.3'
-  gem.add_runtime_dependency 'googleauth', '~> 0.5'
-  gem.add_runtime_dependency 'grpc', '~> 1.2.5'
+  gem.add_runtime_dependency 'google-api-client', '~> 0.17'
+  gem.add_runtime_dependency 'google-cloud-logging', '~> 1.3', '>= 1.3.2'
+  gem.add_runtime_dependency 'googleauth', '~> 0.6'
+  gem.add_runtime_dependency 'grpc', '~> 1.0'
   gem.add_runtime_dependency 'json', '~> 1.8'
 
   gem.add_development_dependency 'mocha', '~> 1.1'

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -120,6 +120,7 @@ module Fluent
       DEFAULT_SOURCE_LOCATION_KEY =
         'logging.googleapis.com/sourceLocation'.freeze
       DEFAULT_TRACE_KEY = 'logging.googleapis.com/trace'.freeze
+      DEFAULT_SPAN_ID_KEY = 'logging.googleapis.com/spanId'.freeze
 
       DEFAULT_METADATA_AGENT_URL =
         'http://local-metadata-agent.stackdriver.com:8000'.freeze
@@ -232,6 +233,7 @@ module Fluent
     config_param :source_location_key, :string, :default =>
       DEFAULT_SOURCE_LOCATION_KEY
     config_param :trace_key, :string, :default => DEFAULT_TRACE_KEY
+    config_param :span_id_key, :string, :default => DEFAULT_SPAN_ID_KEY
 
     # Whether to try to detect if the record is a text log entry with JSON
     # content that needs to be parsed.
@@ -539,6 +541,9 @@ module Fluent
           # Get fully-qualified trace id for LogEntry "trace" field.
           fq_trace_id = record.delete(@trace_key)
           entry.trace = fq_trace_id if fq_trace_id
+
+          span_id = record.delete(@span_id_key)
+          entry.span_id = span_id if span_id
 
           set_log_entry_fields(record, entry)
           set_payload(entry_level_resource.type, record, entry, is_json)

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1154,55 +1154,14 @@ module BaseTest
   end
 
   def test_log_entry_trace_field
-    setup_gce_metadata_stubs
-    message = log_entry(0)
-    trace = 'projects/project-1/traces/1234567890abcdef1234567890abcdef'
-    [
-      {
-        # It leaves trace entry field nil if no trace value sent.
-        driver_config: APPLICATION_DEFAULT_CONFIG,
-        emitted_log: { 'msg' => message },
-        expected_fields: { 'msg' => message },
-        expected_trace_value: nil
-      },
-      {
-        # By default, it sets trace via Google-specific key.
-        driver_config: APPLICATION_DEFAULT_CONFIG,
-        emitted_log: { 'msg' => message, DEFAULT_TRACE_KEY => trace },
-        expected_fields: { 'msg' => message },
-        expected_trace_value: trace
-      },
-      {
-        # It allows setting the trace via a custom configured key.
-        driver_config: CONFIG_CUSTOM_TRACE_KEY_SPECIFIED,
-        emitted_log: { 'msg' => message, 'custom_trace_key' => trace },
-        expected_fields: { 'msg' => message },
-        expected_trace_value: trace
-      },
-      {
-        # It no longer sets trace by the default key if custom key specified.
-        driver_config: CONFIG_CUSTOM_TRACE_KEY_SPECIFIED,
-        emitted_log: { 'msg' => message, DEFAULT_TRACE_KEY => trace },
-        expected_fields: { 'msg' => message, DEFAULT_TRACE_KEY => trace },
-        expected_trace_value: nil
-      }
-    ].each do |input|
-      setup_logging_stubs do
-        @logs_sent = []
-        d = create_driver(input[:driver_config])
-        d.emit(input[:emitted_log])
-        d.run
-      end
-      verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-        assert_equal input[:expected_trace_value], entry['trace'], input
+    verify_field_key('trace', DEFAULT_TRACE_KEY, 'custom_trace_key',
+                     CONFIG_CUSTOM_TRACE_KEY_SPECIFIED,
+                     'projects/proj1/traces/1234567890abcdef1234567890abcdef')
+  end
 
-        fields = get_fields(entry['jsonPayload'])
-        assert_equal input[:expected_fields].size, fields.size, input
-        fields.each do |key, value|
-          assert_equal input[:expected_fields][key], get_string(value), input
-        end
-      end
-    end
+  def test_log_entry_span_id_field
+    verify_field_key('spanId', DEFAULT_SPAN_ID_KEY, 'custom_span_id_key',
+                     CONFIG_CUSTOM_SPAN_ID_KEY_SPECIFIED, '000000000000004a')
   end
 
   # Metadata Agent related tests.
@@ -1762,6 +1721,57 @@ module BaseTest
       field = get_fields(entry['jsonPayload'])[payload_key]
       assert_equal 'a_string', get_string(field), entry
       assert_nil entry[destination_key], entry
+    end
+  end
+
+  def verify_field_key(log_entry_field, default_key, custom_key,
+                       custom_key_config, sample_value)
+    setup_gce_metadata_stubs
+    message = log_entry(0)
+    [
+      {
+        # It leaves log entry field nil if no keyed value sent.
+        driver_config: APPLICATION_DEFAULT_CONFIG,
+        emitted_log: { 'msg' => message },
+        expected_payload: { 'msg' => message },
+        expected_field_value: nil
+      },
+      {
+        # By default, it sets log entry field via a default key.
+        driver_config: APPLICATION_DEFAULT_CONFIG,
+        emitted_log: { 'msg' => message, default_key => sample_value },
+        expected_payload: { 'msg' => message },
+        expected_field_value: sample_value
+      },
+      {
+        # It allows setting the log entry field via a custom configured key.
+        driver_config: custom_key_config,
+        emitted_log: { 'msg' => message, custom_key => sample_value },
+        expected_payload: { 'msg' => message },
+        expected_field_value: sample_value
+      },
+      {
+        # It doesn't set log entry field by default key if custom key specified.
+        driver_config: custom_key_config,
+        emitted_log: { 'msg' => message, default_key => sample_value },
+        expected_payload: { 'msg' => message, default_key => sample_value },
+        expected_field_value: nil
+      }
+    ].each do |input|
+      setup_logging_stubs do
+        @logs_sent = []
+        d = create_driver(input[:driver_config])
+        d.emit(input[:emitted_log])
+        d.run
+      end
+      verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+        assert_equal input[:expected_field_value], entry[log_entry_field], input
+        payload_fields = get_fields(entry['jsonPayload'])
+        assert_equal input[:expected_payload].size, payload_fields.size, input
+        payload_fields.each do |key, value|
+          assert_equal input[:expected_payload][key], get_string(value), input
+        end
+      end
     end
   end
 

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -244,6 +244,10 @@ module Constants
     trace_key custom_trace_key
   ).freeze
 
+  CONFIG_CUSTOM_SPAN_ID_KEY_SPECIFIED = %(
+    span_id_key custom_span_id_key
+  ).freeze
+
   # Service configurations for various services.
 
   # GCE.


### PR DESCRIPTION
This is a revert of #196 , which reverts #180 . 

BTW, there is an issue that I observed after the upgrade of `google-cloud-logging`: https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1938. It does not seem to be a blocking thing though. We are not getting that warning in Fluentd logs.