### PR TITLE
Fix use of deprecated parameter name.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1875,7 +1875,7 @@ module Fluent
         end
         port = ":#{uri.port}" if uri.port
         @client = Google::Cloud::Logging::V2::LoggingServiceV2Client.new(
-          channel: GRPC::Core::Channel.new("#{host}#{port}", nil, creds))
+          credentials: GRPC::Core::Channel.new("#{host}#{port}", nil, creds))
       else
         # TODO: Use a non-default ClientOptions object.
         Google::Apis::ClientOptions.default.application_name = PLUGIN_NAME


### PR DESCRIPTION
This should address https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1938.