### PR TITLE
Consider partially successful requests successful in the counter.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -745,6 +745,8 @@ module Fluent
             @log.warn "Dropping #{partial_errors_count} log message(s)",
                       error: error_message, error_code: error_code.to_s
           end
+          # Consider partially successful requests successful.
+          increment_successful_requests_count
           increment_ingested_entries_count(entries_count)
         end
 

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -65,7 +65,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       end
       d.run
       assert_prometheus_metric_value(
-        :stackdriver_successful_requests_count, 0,
+        :stackdriver_successful_requests_count, 1,
         grpc: true, code: GRPC::Core::StatusCodes::OK)
       assert_prometheus_metric_value(
         :stackdriver_failed_requests_count, 0,


### PR DESCRIPTION
We've been doing this for REST for now. Should do it for gRPC as well. This change should have been a part of https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/174.

A more accurate solution will be addressed in b/70337435.