### PR TITLE
Refactor and combine Prometheus and Partial Success tests.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 1500
 Metrics/ModuleLength:
-  Max: 2000
+  Max: 2500
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -140,61 +140,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     assert_equal 1, exception_count
   end
 
-  # TODO: The code in the non-gRPC and gRPC tests is nearly identical.
-  # Refactor and remove duplication.
-  # TODO: Use status codes instead of int literals.
-  def test_prometheus_metrics
-    setup_gce_metadata_stubs
-    [
-      # Single successful request.
-      [200, 1, 1, [1, 0, 1, 0, 0]],
-      # Several successful requests.
-      [200, 2, 1, [2, 0, 2, 0, 0]],
-      # Single successful request with several entries.
-      [200, 1, 2, [1, 0, 2, 0, 0]],
-      # Single failed request that causes logs to be dropped.
-      [401, 1, 1, [0, 1, 0, 1, 0]],
-      # Single failed request that escalates without logs being dropped with
-      # several entries.
-      [500, 1, 2, [0, 0, 0, 0, 2]]
-    ].each do |code, request_count, entry_count, metric_values|
-      setup_prometheus
-      setup_logging_stubs(code: code, message: 'Some Message') do
-        (1..request_count).each do
-          d = create_driver(ENABLE_PROMETHEUS_CONFIG)
-          (1..entry_count).each do |i|
-            d.emit('message' => log_entry(i.to_s))
-          end
-          # rubocop:disable Lint/HandleExceptions
-          begin
-            d.run
-          rescue Google::Apis::AuthorizationError
-          rescue Google::Apis::ServerError
-          end
-          # rubocop:enable Lint/HandleExceptions
-        end
-        successful_requests_count, failed_requests_count,
-          ingested_entries_count, dropped_entries_count,
-          retried_entries_count = metric_values
-        assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                       successful_requests_count,
-                                       grpc: false, code: 200)
-        assert_prometheus_metric_value(:stackdriver_failed_requests_count,
-                                       failed_requests_count,
-                                       grpc: false, code: code)
-        assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                       ingested_entries_count,
-                                       grpc: false, code: 200)
-        assert_prometheus_metric_value(:stackdriver_dropped_entries_count,
-                                       dropped_entries_count,
-                                       grpc: false, code: code)
-        assert_prometheus_metric_value(:stackdriver_retried_entries_count,
-                                       retried_entries_count,
-                                       grpc: false, code: code)
-      end
-    end
-  end
-
   # This test looks similar between the grpc and non-grpc paths except that when
   # parsing "105", the grpc path responds with "DEBUG", while the non-grpc path
   # responds with "100".
@@ -433,5 +378,13 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     SOURCE_LOCATION_MESSAGE.merge(
       'line' => SOURCE_LOCATION_MESSAGE['line'].to_s
     )
+  end
+
+  def status_codes
+    {
+      ok: 200,
+      unauthorized: 401,
+      server_error: 500
+    }
   end
 end

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -172,60 +172,6 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     end
   end
 
-  # TODO: The code in the non-gRPC and gRPC tests is nearly identical.
-  # Refactor and remove duplication.
-  # TODO: Use status codes instead of int literals.
-  def test_prometheus_metrics
-    setup_gce_metadata_stubs
-    [
-      # Single successful request.
-      [0, 1, 1, [1, 0, 1, 0, 0]],
-      # Several successful requests.
-      [0, 2, 1, [2, 0, 2, 0, 0]],
-      # Single successful request with several entries.
-      [0, 1, 2, [1, 0, 2, 0, 0]],
-      # Single failed request that causes logs to be dropped.
-      [16, 1, 1, [0, 1, 0, 1, 0]],
-      # Single failed request that escalates without logs being dropped with
-      # several entries.
-      [13, 1, 2, [0, 0, 0, 0, 2]]
-    ].each do |code, request_count, entry_count, metric_values|
-      setup_prometheus
-      setup_logging_stubs(code: code, message: 'SomeMessage') do
-        (1..request_count).each do
-          d = create_driver(USE_GRPC_CONFIG + ENABLE_PROMETHEUS_CONFIG, 'test')
-          (1..entry_count).each do |i|
-            d.emit('message' => log_entry(i.to_s))
-          end
-          # rubocop:disable Lint/HandleExceptions
-          begin
-            d.run
-          rescue GRPC::BadStatus
-          end
-          # rubocop:enable Lint/HandleExceptions
-        end
-      end
-      successful_requests_count, failed_requests_count,
-        ingested_entries_count, dropped_entries_count,
-        retried_entries_count = metric_values
-      assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                     successful_requests_count,
-                                     grpc: true, code: 0)
-      assert_prometheus_metric_value(:stackdriver_failed_requests_count,
-                                     failed_requests_count,
-                                     grpc: true, code: code)
-      assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                     ingested_entries_count,
-                                     grpc: true, code: 0)
-      assert_prometheus_metric_value(:stackdriver_dropped_entries_count,
-                                     dropped_entries_count,
-                                     grpc: true, code: code)
-      assert_prometheus_metric_value(:stackdriver_retried_entries_count,
-                                     retried_entries_count,
-                                     grpc: true, code: code)
-    end
-  end
-
   # This test looks similar between the grpc and non-grpc paths except that when
   # parsing "105", the grpc path responds with "DEBUG", while the non-grpc path
   # responds with "100".
@@ -491,5 +437,13 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
   # The null value.
   def null_value
     { 'nullValue' => 'NULL_VALUE' }
+  end
+
+  def status_codes
+    {
+      ok: GRPC::Core::StatusCodes::OK,
+      unauthorized: GRPC::Core::StatusCodes::UNAUTHENTICATED,
+      server_error: GRPC::Core::StatusCodes::INTERNAL
+    }
   end
 end


### PR DESCRIPTION
The goal is to unify the method `setup_logging_stubs` and combine grpc and non-grpc tests when the difference is very minimum.