### PR TITLE
Support passing metadata agent url via an environment variable STACKDRIVER_METADATA_AGENT_URL.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 1300
 Metrics/ModuleLength:
-  Max: 1600
+  Max: 1700
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -124,6 +124,7 @@ module Fluent
 
       DEFAULT_METADATA_AGENT_URL =
         'http://local-metadata-agent.stackdriver.com:8000'.freeze
+      METADATA_AGENT_URL_ENV_VAR_NAME = 'STACKDRIVER_METADATA_AGENT_URL'.freeze
     end
 
     # Internal constants.
@@ -385,6 +386,17 @@ module Fluent
                   ' enabled. Customized logging_api_url for the non-gRPC path' \
                   ' is not supported. The logging_api_url option will be' \
                   ' ignored.'
+      end
+
+      if @enable_metadata_agent
+        # 1. If @metadata_agent_url is customized, use that.
+        # 2. Otherwise check the environment variable
+        #    STACKDRIVER_METADATA_AGENT_URL.
+        # 3. Fall back to the default
+        if @metadata_agent_url == DEFAULT_METADATA_AGENT_URL && \
+           !ENV[METADATA_AGENT_URL_ENV_VAR_NAME].to_s.empty?
+          @metadata_agent_url = ENV[METADATA_AGENT_URL_ENV_VAR_NAME]
+        end
       end
 
       # If monitoring is enabled, register metrics in the default registry
@@ -1384,7 +1396,7 @@ module Fluent
         return parsed_hash
       end
     rescue StandardError => e
-      @log.error 'Error calling Metadata Agent.', error: e
+      @log.error "Error calling Metadata Agent at #{url}.", error: e
     end
 
     # TODO: This functionality should eventually be available in another

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -352,12 +352,11 @@ module Fluent
     # Whether to call metadata agent to retrieve monitored resource.
     config_param :enable_metadata_agent, :bool, :default => false
 
-    # The URL of Metadata Agent.
-    # If this option is not nil, its value will be used.
-    # If this option is nil, we will first check if the environment variable
-    # STACKDRIVER_METADATA_AGENT_URL is set and use that if possible.
-    # If that environment variable is also absent, the default url
-    # 'http://local-metadata-agent.stackdriver.com:8000' will be used.
+    # The URL of the Metadata Agent.
+    # If this option is set, its value is used to contact the Metadata Agent.
+    # Otherwise, the value of the STACKDRIVER_METADATA_AGENT_URL environment
+    # variable is used. If that is also unset, this defaults to
+    # 'http://local-metadata-agent.stackdriver.com:8000'.
     config_param :metadata_agent_url, :string, :default => nil
 
     # Whether to split log entries with different log tags into different

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -351,6 +351,11 @@ module Fluent
 
     # Whether to call metadata agent to retrieve monitored resource.
     config_param :enable_metadata_agent, :bool, :default => false
+
+    # The url of Metadata Agent. If this config is not customized (left as
+    # default instead) while an environment variable
+    # STACKDRIVER_METADATA_AGENT_URL is set, the value of that variable will
+    # take precedence. Otherwise the value of this config will be used.
     config_param :metadata_agent_url, :string,
                  :default => DEFAULT_METADATA_AGENT_URL
 

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -124,7 +124,7 @@ module Fluent
 
       DEFAULT_METADATA_AGENT_URL =
         'http://local-metadata-agent.stackdriver.com:8000'.freeze
-      METADATA_AGENT_URL_ENV_VAR_NAME = 'STACKDRIVER_METADATA_AGENT_URL'.freeze
+      METADATA_AGENT_URL_ENV_VAR = 'STACKDRIVER_METADATA_AGENT_URL'.freeze
     end
 
     # Internal constants.
@@ -400,10 +400,10 @@ module Fluent
       if @enable_metadata_agent
         # Convert to string to capture empty string.
         @metadata_agent_url ||=
-          if ENV[METADATA_AGENT_URL_ENV_VAR_NAME].to_s.empty?
+          if ENV[METADATA_AGENT_URL_ENV_VAR].to_s.empty?
             DEFAULT_METADATA_AGENT_URL
           else
-            ENV[METADATA_AGENT_URL_ENV_VAR_NAME]
+            ENV[METADATA_AGENT_URL_ENV_VAR]
           end
       end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -121,10 +121,14 @@ module BaseTest
       # If @metadata_agent_url is customized, use that even if the environment
       # variable is set.
       [CUSTOM_METADATA_AGENT_URL_CONFIG, true, CUSTOM_METADATA_AGENT_URL],
-      # If metadata_agent_url is not customized and the environment variable is
+      # If @metadata_agent_url is customized and the environment variable is
+      # not set, use @metadata_agent_url.
+      [CUSTOM_METADATA_AGENT_URL_CONFIG, false, CUSTOM_METADATA_AGENT_URL],
+      # If @metadata_agent_url is not customized and the environment variable is
       # set, use the env.
       [APPLICATION_DEFAULT_CONFIG, true, METADATA_AGENT_URL_FROM_ENV],
-      # Fall back to the default.
+      # If @metadata_agent_url is not customized and the environment variable is
+      # not set, fall back to the default.
       [APPLICATION_DEFAULT_CONFIG, false, DEFAULT_METADATA_AGENT_URL]
     ].each do |(config, url_from_env, expected_url)|
       ENV[METADATA_AGENT_URL_ENV_VAR_NAME] = METADATA_AGENT_URL_FROM_ENV if

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -131,12 +131,12 @@ module BaseTest
       # not set, fall back to the default.
       [APPLICATION_DEFAULT_CONFIG, false, DEFAULT_METADATA_AGENT_URL]
     ].each do |(config, url_from_env, expected_url)|
-      ENV[METADATA_AGENT_URL_ENV_VAR_NAME] = METADATA_AGENT_URL_FROM_ENV if
+      ENV[METADATA_AGENT_URL_ENV_VAR] = METADATA_AGENT_URL_FROM_ENV if
         url_from_env
       setup_gce_metadata_stubs
       d = create_driver(ENABLE_METADATA_AGENT_CONFIG + config)
       assert_equal expected_url, d.instance.metadata_agent_url
-      ENV.delete(METADATA_AGENT_URL_ENV_VAR_NAME)
+      ENV.delete(METADATA_AGENT_URL_ENV_VAR)
     end
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -118,16 +118,16 @@ module BaseTest
 
   def test_metadata_agent_url_customization
     [
-      # If @metadata_agent_url is customized, use that even if the environment
+      # If @metadata_agent_url is set, use that even if the environment
       # variable is set.
       [CUSTOM_METADATA_AGENT_URL_CONFIG, true, CUSTOM_METADATA_AGENT_URL],
-      # If @metadata_agent_url is customized and the environment variable is
+      # If @metadata_agent_url is set and the environment variable is
       # not set, use @metadata_agent_url.
       [CUSTOM_METADATA_AGENT_URL_CONFIG, false, CUSTOM_METADATA_AGENT_URL],
-      # If @metadata_agent_url is not customized and the environment variable is
-      # set, use the env.
+      # If @metadata_agent_url is not set and the environment variable is set,
+      # use the env.
       [APPLICATION_DEFAULT_CONFIG, true, METADATA_AGENT_URL_FROM_ENV],
-      # If @metadata_agent_url is not customized and the environment variable is
+      # If @metadata_agent_url is not set and the environment variable is
       # not set, fall back to the default.
       [APPLICATION_DEFAULT_CONFIG, false, DEFAULT_METADATA_AGENT_URL]
     ].each do |(config, url_from_env, expected_url)|

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -116,6 +116,26 @@ module BaseTest
     end
   end
 
+  def test_metadata_agent_url_customization
+    [
+      # If @metadata_agent_url is customized, use that even if the environment
+      # variable is set.
+      [CUSTOM_METADATA_AGENT_URL_CONFIG, true, CUSTOM_METADATA_AGENT_URL],
+      # If metadata_agent_url is not customized and the environment variable is
+      # set, use the env.
+      [APPLICATION_DEFAULT_CONFIG, true, METADATA_AGENT_URL_FROM_ENV],
+      # Fall back to the default.
+      [APPLICATION_DEFAULT_CONFIG, false, DEFAULT_METADATA_AGENT_URL]
+    ].each do |(config, url_from_env, expected_url)|
+      ENV[METADATA_AGENT_URL_ENV_VAR_NAME] = METADATA_AGENT_URL_FROM_ENV if
+        url_from_env
+      setup_gce_metadata_stubs
+      d = create_driver(ENABLE_METADATA_AGENT_CONFIG + config)
+      assert_equal expected_url, d.instance.metadata_agent_url
+      ENV.delete(METADATA_AGENT_URL_ENV_VAR_NAME)
+    end
+  end
+
   def test_metadata_loading
     setup_gce_metadata_stubs
     d = create_driver

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -21,6 +21,8 @@ module Constants
   # Generic attributes.
   HOSTNAME = Socket.gethostname
   CUSTOM_LOGGING_API_URL = 'http://localhost:52000'.freeze
+  CUSTOM_METADATA_AGENT_URL = 'http://localhost:12345'.freeze
+  METADATA_AGENT_URL_FROM_ENV = 'http://localhost:54321'.freeze
 
   # TODO(qingling128) Separate constants into different submodules.
   # Attributes used for the GCE metadata service.
@@ -144,6 +146,10 @@ module Constants
 
   CUSTOM_LOGGING_API_URL_CONFIG = %(
     logging_api_url #{CUSTOM_LOGGING_API_URL}
+  ).freeze
+
+  CUSTOM_METADATA_AGENT_URL_CONFIG = %(
+    metadata_agent_url #{CUSTOM_METADATA_AGENT_URL}
   ).freeze
 
   DETECT_JSON_CONFIG = %(


### PR DESCRIPTION
We need to determine "best practices" on the topic of setting a dynamic metadata_agent_url which is dependent on the environment the logging agent is running in. Having the default set to "http://local-metadata-agent.stackdriver.com:8000" only works well when the metadata agent is discoverable on the same network as the logging agent. 

The decision is to support a new configuration parameter that specifies the environment variable `STACKDRIVER_METADATA_AGENT_URL`, which is evaluated after checking the metadata_agent_url before falling back to default.