### PR TITLE
Remove 'Name' from docker and gke local_resource_id prefixes.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1182,8 +1182,8 @@ module Fluent
       # Metadata Agent with this key.
       #
       # Examples:
-      #   "container.<container_id>"
-      #   "k8s_pod.<cluster_name>.<namespace_name>.<pod_name>.<location>"
+      # "container.<container_id>" // Docker container.
+      # "k8s_pod.<namespace_name>.<pod_name>" // GKE pod.
       if @enable_metadata_agent && local_resource_id
         @log.debug 'Calling metadata agent with local_resource_id: ' \
                   "#{local_resource_id}."

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1181,11 +1181,9 @@ module Fluent
       # inferred from the tag) if failed to get a monitored resource from
       # Metadata Agent with this key.
       #
-      # Docker container:
+      # Examples:
       #   "container.<container_id>"
-      #   "containerName.<container_name>"
-      # GKE container:
-      #   "gke_containerName.<namespace_id>.<pod_name>.<container_name>"
+      #   "k8s_pod.<cluster_name>.<namespace_name>.<pod_name>.<location>"
       if @enable_metadata_agent && local_resource_id
         @log.debug 'Calling metadata agent with local_resource_id: ' \
                   "#{local_resource_id}."

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1260,7 +1260,7 @@ module BaseTest
 
   # Test logs from applications running in Docker containers. These logs have
   # the label "logging.googleapis.com/local_resource_id" set in the format of
-  # "containerName.<container_name>".
+  # "container.<container_name>".
   def test_docker_container_application_logs
     new_stub_context do
       setup_gce_metadata_stubs
@@ -1274,7 +1274,7 @@ module BaseTest
       end
       verify_log_entries(1, DOCKER_CONTAINER_PARAMS_NO_STREAM)
       assert_requested_metadata_agent_stub(
-        "containerName.#{DOCKER_CONTAINER_NAME}")
+        "#{DOCKER_CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{DOCKER_CONTAINER_NAME}")
     end
   end
 
@@ -1298,7 +1298,7 @@ module BaseTest
                      entry['timestamp']['nanos'], entry
       end
       assert_requested_metadata_agent_stub(
-        "containerName.#{DOCKER_CONTAINER_NAME}")
+        "#{DOCKER_CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{DOCKER_CONTAINER_NAME}")
     end
   end
 
@@ -1333,7 +1333,7 @@ module BaseTest
 
   # Test GKE container logs. These logs have the label
   # "logging.googleapis.com/local_resource_id" set in the format of
-  # "gke_containerName.<namespace_id>.<pod_name>.<container_name>".
+  # "gke_container.<namespace_id>.<pod_name>.<container_name>".
   def test_gke_container_logs
     [1, 2, 3, 5, 11, 50].each do |n|
       new_stub_context do
@@ -1349,8 +1349,8 @@ module BaseTest
         end
         verify_log_entries(n, CONTAINER_FROM_APPLICATION_PARAMS)
         assert_requested_metadata_agent_stub(
-          "gke_containerName.#{CONTAINER_NAMESPACE_ID}.#{CONTAINER_POD_NAME}." \
-          "#{CONTAINER_CONTAINER_NAME}")
+          "#{CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{CONTAINER_NAMESPACE_ID}" \
+          ".#{CONTAINER_POD_NAME}.#{CONTAINER_CONTAINER_NAME}")
       end
     end
   end
@@ -1533,7 +1533,7 @@ module BaseTest
     {
       log: log,
       LOCAL_RESOURCE_ID_KEY =>
-        "gke_containerName.#{CONTAINER_NAMESPACE_ID}" \
+        "#{CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{CONTAINER_NAMESPACE_ID}" \
         ".#{CONTAINER_POD_NAME}.#{CONTAINER_CONTAINER_NAME}"
     }
   end
@@ -1559,7 +1559,8 @@ module BaseTest
     {
       log: log,
       time: DOCKER_CONTAINER_TIMESTAMP,
-      LOCAL_RESOURCE_ID_KEY => "containerName.#{DOCKER_CONTAINER_NAME}"
+      LOCAL_RESOURCE_ID_KEY => "#{DOCKER_CONTAINER_LOCAL_RESOURCE_ID_PREFIX}." \
+                               "#{DOCKER_CONTAINER_NAME}"
     }
   end
 

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -71,6 +71,7 @@ module Constants
   DOCKER_CONTAINER_TIMESTAMP = '2009-02-13T23:31:30.987654321Z'.freeze
   DOCKER_CONTAINER_SECONDS_EPOCH = 1_234_567_890
   DOCKER_CONTAINER_NANOS = 987_654_321
+  DOCKER_CONTAINER_LOCAL_RESOURCE_ID_PREFIX = 'container'.freeze
 
   # Container Engine / Kubernetes specific labels.
   CONTAINER_CLUSTER_NAME = 'cluster-1'.freeze
@@ -87,6 +88,7 @@ module Constants
   CONTAINER_TIMESTAMP = '2009-02-13T23:31:30.987654321Z'.freeze
   CONTAINER_SECONDS_EPOCH = 1_234_567_890
   CONTAINER_NANOS = 987_654_321
+  CONTAINER_LOCAL_RESOURCE_ID_PREFIX = 'gke_container'.freeze
 
   # Cloud Functions specific labels.
   CLOUDFUNCTIONS_FUNCTION_NAME = '$My_Function.Name-@1'.freeze
@@ -605,7 +607,7 @@ module Constants
   # Map from the local_resource_id to the retrieved monitored resource.
   MONITORED_RESOURCE_STUBS = {
     # Docker container stderr / stdout logs.
-    "container.#{DOCKER_CONTAINER_ID}" =>
+    "#{DOCKER_CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{DOCKER_CONTAINER_ID}" =>
       {
         'type' => DOCKER_CONSTANTS[:resource_type],
         'labels' => {
@@ -614,7 +616,7 @@ module Constants
         }
       }.to_json,
     # Docker container application logs.
-    "containerName.#{DOCKER_CONTAINER_NAME}" =>
+    "#{DOCKER_CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{DOCKER_CONTAINER_NAME}" =>
       {
         'type' => DOCKER_CONSTANTS[:resource_type],
         'labels' => {
@@ -623,8 +625,8 @@ module Constants
         }
       }.to_json,
     # GKE container logs.
-    "gke_containerName.#{CONTAINER_NAMESPACE_ID}.#{CONTAINER_POD_NAME}." \
-    "#{CONTAINER_CONTAINER_NAME}" =>
+    "#{CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{CONTAINER_NAMESPACE_ID}" \
+    ".#{CONTAINER_POD_NAME}.#{CONTAINER_CONTAINER_NAME}" =>
       {
         'type' => GKE_CONSTANTS[:resource_type],
         'labels' => {


### PR DESCRIPTION
This is to align with https://github.com/Stackdriver/metadata-agent/pull/56.

The change here does not affect functionality, just the test stubs.