### PR TITLE
Disable split_logs_by_tag by default and fix a corner case when no valid entry is present.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -382,7 +382,7 @@ module Fluent
 
     # Whether to split log entries with different log tags into different
     # requests when talking to Stackdriver Logging API.
-    config_param :split_logs_by_tag, :bool, :default => true
+    config_param :split_logs_by_tag, :bool, :default => false
 
     # rubocop:enable Style/HashSyntax
 

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -632,7 +632,8 @@ module Fluent
           end
           combined_entries.concat(request[:entries])
         end
-        @write_request.call(entries: combined_entries)
+        @write_request.call(entries: combined_entries) unless
+          combined_entries.empty?
       end
     end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -658,7 +658,7 @@ module BaseTest
     setup_gce_metadata_stubs
     {
       APPLICATION_DEFAULT_CONFIG => false,
-      SPLIT_LOGS_BY_TAG_ENABLE_CONFIG => true
+      ENABLE_SPLIT_LOGS_BY_TAG_CONFIG => true
     }.each do |(config, split_logs_by_tag)|
       d = create_driver(config)
       assert_equal split_logs_by_tag,
@@ -675,12 +675,12 @@ module BaseTest
     [
       [APPLICATION_DEFAULT_CONFIG, 1, [''], dynamic_log_names],
       # [] returns nil for any index.
-      [SPLIT_LOGS_BY_TAG_ENABLE_CONFIG, log_entry_count, dynamic_log_names, []]
+      [ENABLE_SPLIT_LOGS_BY_TAG_CONFIG, log_entry_count, dynamic_log_names, []]
     ].each do |(config, request_count, request_log_names, entry_log_names)|
       setup_prometheus
       setup_logging_stubs do
         @logs_sent = []
-        d = create_driver(config + PROMETHEUS_ENABLE_CONFIG, 'test', true)
+        d = create_driver(config + ENABLE_PROMETHEUS_CONFIG, 'test', true)
         log_entry_count.times do |i|
           d.emit("tag#{i}", 'message' => log_entry(i))
         end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -657,8 +657,8 @@ module BaseTest
   def test_configure_split_logs_by_tag
     setup_gce_metadata_stubs
     {
-      APPLICATION_DEFAULT_CONFIG => true,
-      DISABLE_SPLIT_LOGS_BY_TAG_CONFIG => false
+      APPLICATION_DEFAULT_CONFIG => false,
+      SPLIT_LOGS_BY_TAG_ENABLE_CONFIG => true
     }.each do |(config, split_logs_by_tag)|
       d = create_driver(config)
       assert_equal split_logs_by_tag,
@@ -674,8 +674,8 @@ module BaseTest
     end
     [
       # [] returns nil for any index.
-      [APPLICATION_DEFAULT_CONFIG, log_entry_count, dynamic_log_names, []],
-      [DISABLE_SPLIT_LOGS_BY_TAG_CONFIG, 1, [''], dynamic_log_names]
+      [SPLIT_LOGS_BY_TAG_ENABLE_CONFIG, log_entry_count, dynamic_log_names, []],
+      [APPLICATION_DEFAULT_CONFIG, 1, [''], dynamic_log_names]
     ].each do |(config, request_count, request_log_names, entry_log_names)|
       setup_prometheus
       setup_logging_stubs do

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -673,9 +673,9 @@ module BaseTest
       "projects/test-project-id/logs/tag#{index}"
     end
     [
+      [APPLICATION_DEFAULT_CONFIG, 1, [''], dynamic_log_names],
       # [] returns nil for any index.
-      [SPLIT_LOGS_BY_TAG_ENABLE_CONFIG, log_entry_count, dynamic_log_names, []],
-      [APPLICATION_DEFAULT_CONFIG, 1, [''], dynamic_log_names]
+      [SPLIT_LOGS_BY_TAG_ENABLE_CONFIG, log_entry_count, dynamic_log_names, []]
     ].each do |(config, request_count, request_log_names, entry_log_names)|
       setup_prometheus
       setup_logging_stubs do

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -186,8 +186,8 @@ module Constants
     detect_subservice false
   ).freeze
 
-  DISABLE_SPLIT_LOGS_BY_TAG_CONFIG = %(
-    split_logs_by_tag false
+  SPLIT_LOGS_BY_TAG_ENABLE_CONFIG = %(
+    split_logs_by_tag true
   ).freeze
 
   PROMETHEUS_ENABLE_CONFIG = %(

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -186,11 +186,11 @@ module Constants
     detect_subservice false
   ).freeze
 
-  SPLIT_LOGS_BY_TAG_ENABLE_CONFIG = %(
+  ENABLE_SPLIT_LOGS_BY_TAG_CONFIG = %(
     split_logs_by_tag true
   ).freeze
 
-  PROMETHEUS_ENABLE_CONFIG = %(
+  ENABLE_PROMETHEUS_CONFIG = %(
     enable_monitoring true
     monitoring_type prometheus
   ).freeze

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -61,7 +61,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     stub_request(:post, WRITE_LOG_ENTRIES_URI)
       .to_return(status: root_error_code,
                  body: PARTIAL_SUCCESS_RESPONSE_BODY.to_json)
-    d = create_driver(PROMETHEUS_ENABLE_CONFIG)
+    d = create_driver(ENABLE_PROMETHEUS_CONFIG)
     4.times do |i|
       d.emit('message' => log_entry(i.to_s))
     end
@@ -123,7 +123,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       stub_request(:post, WRITE_LOG_ENTRIES_URI)
         .to_return(status: code, body: 'Some Message')
       (1..request_count).each do
-        d = create_driver(PROMETHEUS_ENABLE_CONFIG)
+        d = create_driver(ENABLE_PROMETHEUS_CONFIG)
         (1..entry_count).each do |i|
           d.emit('message' => log_entry(i.to_s))
         end

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -59,7 +59,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       'User not authorized.', PARTIAL_SUCCESS_GRPC_METADATA) do
       # The API Client should not retry this and the plugin should consume
       # the exception.
-      d = create_driver(PROMETHEUS_ENABLE_CONFIG)
+      d = create_driver(ENABLE_PROMETHEUS_CONFIG)
       4.times do |i|
         d.emit('message' => log_entry(i.to_s))
       end
@@ -131,7 +131,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       setup_prometheus
       (1..request_count).each do
         setup_logging_stubs(should_fail, code, 'SomeMessage') do
-          d = create_driver(USE_GRPC_CONFIG + PROMETHEUS_ENABLE_CONFIG, 'test')
+          d = create_driver(USE_GRPC_CONFIG + ENABLE_PROMETHEUS_CONFIG, 'test')
           (1..entry_count).each do |i|
             d.emit('message' => log_entry(i.to_s))
           end


### PR DESCRIPTION
This option controls whether Stackdriver Logging Agent will split logs into separate requests based on the log tag. If true, logs with each distinct tag will be grouped into their own request. By default this is currently enabled. The original intention behind splitting logs with different tags into their own requests is to avoid repeatedly setting the log name for every log entry in the batch send to Stackdriver Logging, compressing the payload size.

While you might expect that the effect of the optimization above would be minimal, we’ve seen significant performance discrepancies when the number of distinct log tags > 30. In other words, what could all fit into one request get split into >30 requests. This substantially increases latency and consumes significantly more resource usage.

On the other side, we are not seeing obvious performance improvements when tags are < 30. And logging backend folks also suggested that this type of optimization we are doing is not longer very relevant.