### PR TITLE
Unset the credential file path environment variable if the value is an empty string.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -156,6 +156,7 @@ module Fluent
 
     # Internal constants.
     module InternalConstants
+      CREDENTIAL_PATH_VAR = 'GOOGLE_APPLICATION_CREDENTIALS'.freeze
       DEFAULT_LOGGING_API_URL = 'https://logging.googleapis.com'.freeze
 
       # The label name of local_resource_id in the json payload. When a record
@@ -481,6 +482,10 @@ module Fluent
       set_regexp_patterns
 
       @platform = detect_platform
+
+      # Unset the credential file path environment variable if the value is set
+      # to an empty string.
+      ENV.delete(CREDENTIAL_PATH_VAR) if ENV[CREDENTIAL_PATH_VAR] == ''
 
       # Set required variables: @project_id, @vm_id, @vm_name and @zone.
       set_required_metadata_variables

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -156,7 +156,7 @@ module Fluent
 
     # Internal constants.
     module InternalConstants
-      CREDENTIAL_PATH_VAR = 'GOOGLE_APPLICATION_CREDENTIALS'.freeze
+      CREDENTIALS_PATH_ENV_VAR = 'GOOGLE_APPLICATION_CREDENTIALS'.freeze
       DEFAULT_LOGGING_API_URL = 'https://logging.googleapis.com'.freeze
 
       # The label name of local_resource_id in the json payload. When a record
@@ -483,9 +483,10 @@ module Fluent
 
       @platform = detect_platform
 
-      # Unset the credential file path environment variable if the value is set
-      # to an empty string.
-      ENV.delete(CREDENTIAL_PATH_VAR) if ENV[CREDENTIAL_PATH_VAR] == ''
+      # Treat an empty setting of the credentials file path environment variable
+      # as unset. This way the googleauth lib could fetch the credentials
+      # following the fallback path.
+      ENV.delete(CREDENTIALS_PATH_ENV_VAR) if ENV[CREDENTIALS_PATH_ENV_VAR] == ''
 
       # Set required variables: @project_id, @vm_id, @vm_name and @zone.
       set_required_metadata_variables

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -486,7 +486,8 @@ module Fluent
       # Treat an empty setting of the credentials file path environment variable
       # as unset. This way the googleauth lib could fetch the credentials
       # following the fallback path.
-      ENV.delete(CREDENTIALS_PATH_ENV_VAR) if ENV[CREDENTIALS_PATH_ENV_VAR] == ''
+      ENV.delete(CREDENTIALS_PATH_ENV_VAR) if
+        ENV[CREDENTIALS_PATH_ENV_VAR] == ''
 
       # Set required variables: @project_id, @vm_id, @vm_name and @zone.
       set_required_metadata_variables

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -274,11 +274,14 @@ module BaseTest
     end
   end
 
-  def test_unset_empty_credential_env_var
-    ENV[CREDENTIALS_PATH_ENV_VAR] = ''
-    setup_gce_metadata_stubs
-    create_driver
-    assert_nil ENV[CREDENTIALS_PATH_ENV_VAR]
+  def test_unset_empty_credentials_path_env_var
+    # An empty string should be treated as if it's not set.
+    ['', nil].each do |env_var|
+      ENV[CREDENTIALS_PATH_ENV_VAR] = env_var
+      setup_gce_metadata_stubs
+      create_driver
+      assert_nil ENV[CREDENTIALS_PATH_ENV_VAR]
+    end
   end
 
   def test_one_log_custom_metadata

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -274,10 +274,10 @@ module BaseTest
     end
   end
 
-  def test_unset_empty_credentials_path_env_var
+  def test_unset_or_empty_credentials_path_env_var
     # An empty string should be treated as if it's not set.
-    ['', nil].each do |env_var|
-      ENV[CREDENTIALS_PATH_ENV_VAR] = env_var
+    [nil, ''].each do |value|
+      ENV[CREDENTIALS_PATH_ENV_VAR] = value
       setup_gce_metadata_stubs
       create_driver
       assert_nil ENV[CREDENTIALS_PATH_ENV_VAR]

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -274,6 +274,13 @@ module BaseTest
     end
   end
 
+  def test_unset_empty_credential_env_var
+    ENV[CREDENTIAL_PATH_VAR] = ''
+    setup_gce_metadata_stubs
+    create_driver
+    assert_nil ENV[CREDENTIAL_PATH_VAR]
+  end
+
   def test_one_log_custom_metadata
     # don't set up any metadata stubs, so the test will fail if we try to
     # fetch metadata (and explicitly check this as well).

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -27,7 +27,7 @@ module BaseTest
   def setup
     Fluent::Test.setup
     # delete environment variables that googleauth uses to find credentials.
-    ENV.delete('GOOGLE_APPLICATION_CREDENTIALS')
+    ENV.delete(CREDENTIALS_PATH_ENV_VAR)
     # service account env.
     ENV.delete('PRIVATE_KEY_VAR')
     ENV.delete('CLIENT_EMAIL_VAR')
@@ -229,7 +229,7 @@ module BaseTest
       send("setup_#{platform}_metadata_stubs")
       [IAM_CREDENTIALS, NEW_STYLE_CREDENTIALS, LEGACY_CREDENTIALS].each \
       do |creds|
-        ENV['GOOGLE_APPLICATION_CREDENTIALS'] = creds[:path]
+        ENV[CREDENTIALS_PATH_ENV_VAR] = creds[:path]
         d = create_driver
         d.run
         assert_equal creds[:project_id], d.instance.project_id
@@ -249,7 +249,7 @@ module BaseTest
 
   def test_one_log_with_json_credentials
     setup_gce_metadata_stubs
-    ENV['GOOGLE_APPLICATION_CREDENTIALS'] = IAM_CREDENTIALS[:path]
+    ENV[CREDENTIALS_PATH_ENV_VAR] = IAM_CREDENTIALS[:path]
     setup_logging_stubs do
       d = create_driver
       d.emit('message' => log_entry(0))
@@ -263,7 +263,7 @@ module BaseTest
     %w(gce_metadata ec2_metadata no_metadata_service).each do |platform|
       send("setup_#{platform}_stubs")
       exception_count = 0
-      ENV['GOOGLE_APPLICATION_CREDENTIALS'] = INVALID_CREDENTIALS[:path]
+      ENV[CREDENTIALS_PATH_ENV_VAR] = INVALID_CREDENTIALS[:path]
       begin
         create_driver
       rescue RuntimeError => error
@@ -275,17 +275,17 @@ module BaseTest
   end
 
   def test_unset_empty_credential_env_var
-    ENV[CREDENTIAL_PATH_VAR] = ''
+    ENV[CREDENTIALS_PATH_ENV_VAR] = ''
     setup_gce_metadata_stubs
     create_driver
-    assert_nil ENV[CREDENTIAL_PATH_VAR]
+    assert_nil ENV[CREDENTIALS_PATH_ENV_VAR]
   end
 
   def test_one_log_custom_metadata
     # don't set up any metadata stubs, so the test will fail if we try to
     # fetch metadata (and explicitly check this as well).
     Fluent::GoogleCloudOutput.any_instance.expects(:fetch_metadata).never
-    ENV['GOOGLE_APPLICATION_CREDENTIALS'] = IAM_CREDENTIALS[:path]
+    ENV[CREDENTIALS_PATH_ENV_VAR] = IAM_CREDENTIALS[:path]
     setup_logging_stubs do
       d = create_driver(NO_METADATA_SERVICE_CONFIG + CUSTOM_METADATA_CONFIG)
       d.emit('message' => log_entry(0))
@@ -295,7 +295,7 @@ module BaseTest
   end
 
   def test_one_log_ec2
-    ENV['GOOGLE_APPLICATION_CREDENTIALS'] = IAM_CREDENTIALS[:path]
+    ENV[CREDENTIALS_PATH_ENV_VAR] = IAM_CREDENTIALS[:path]
     setup_ec2_metadata_stubs
     setup_logging_stubs do
       d = create_driver(CONFIG_EC2_PROJECT_ID)
@@ -306,7 +306,7 @@ module BaseTest
   end
 
   def test_one_log_ec2_region
-    ENV['GOOGLE_APPLICATION_CREDENTIALS'] = IAM_CREDENTIALS[:path]
+    ENV[CREDENTIALS_PATH_ENV_VAR] = IAM_CREDENTIALS[:path]
     setup_ec2_metadata_stubs
     setup_logging_stubs do
       d = create_driver(CONFIG_EC2_PROJECT_ID_USE_REGION)


### PR DESCRIPTION
This way the googleauth lib knows to fetch the credentials following the fallback path.