### PR TITLE
Use cluster-name directly instead of kube-env to populate cluster_name label

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ desc 'Run unit tests'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.test_files = FileList['test/plugin/*.rb']
+  test.warning = false
   test.verbose = true
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,6 @@ desc 'Run unit tests'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.test_files = FileList['test/plugin/*.rb']
-  test.warning = false
   test.verbose = true
 end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1440,7 +1440,7 @@ module BaseTest
       new_stub_context do
         setup_gce_metadata_stubs
         setup_metadata_agent_stubs(test_params[:setup_metadata_agent_stub])
-	setup_k8s_metadata_stubs(test_params[:setup_k8s_stub])
+        setup_k8s_metadata_stubs(test_params[:setup_k8s_stub])
         setup_logging_stubs do
           d = create_driver(test_params[:config], CONTAINER_TAG)
           d.emit(test_params[:log_entry])
@@ -1500,7 +1500,7 @@ module BaseTest
       new_stub_context do
         setup_gce_metadata_stubs
         setup_metadata_agent_stubs(test_params[:setup_metadata_agent_stub])
-	setup_k8s_metadata_stubs(test_params[:setup_k8s_stub])
+        setup_k8s_metadata_stubs(test_params[:setup_k8s_stub])
         setup_logging_stubs do
           d = create_driver(test_params[:config])
           d.emit(test_params[:log_entry])

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1498,7 +1498,7 @@ module BaseTest
       }
     ].each do |test_params, index|
       new_stub_context do
-	print index
+        print index
         setup_gce_metadata_stubs
         setup_metadata_agent_stubs(test_params[:setup_metadata_agent_stub])
         setup_k8s_metadata_stubs(test_params[:setup_k8s_stub])

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1096,6 +1096,27 @@ module BaseTest
     end
   end
 
+  def test_cloudfunctions_log_kube_env_hidden
+    setup_gce_metadata_stubs
+    setup_cloudfunctions_metadata_stubs_kube_env_hidden
+    [1, 2, 3, 5, 11, 50].each do |n|
+      setup_logging_stubs do
+        d = create_driver(APPLICATION_DEFAULT_CONFIG, CLOUDFUNCTIONS_TAG)
+        # The test driver doesn't clear its buffer of entries after running, so
+        # do it manually here.
+        d.instance_variable_get('@entries').clear
+        @logs_sent = []
+        n.times { |i| d.emit(cloudfunctions_log_entry(i)) }
+        d.run
+      end
+      verify_log_entries(n, CLOUDFUNCTIONS_PARAMS) do |entry, i|
+        verify_default_log_entry_text(entry['textPayload'], i, entry)
+        assert_equal 'DEBUG', entry['severity'],
+                     "Test with #{n} logs failed. \n#{entry}"
+      end
+    end
+  end
+
   def test_dataproc_log
     setup_gce_metadata_stubs
     setup_dataproc_metadata_stubs
@@ -1417,6 +1438,7 @@ module BaseTest
         expected_params: K8S_CONTAINER_PARAMS
       },
       # When local_resource_id is not present or does not match k8s regexes.
+      # TODO these two are busted.
       {
         config: ENABLE_METADATA_AGENT_CONFIG,
         setup_metadata_agent_stub: true,
@@ -1594,6 +1616,30 @@ module BaseTest
     end
   end
 
+  # Test GKE container logs. These logs have the label
+  # "logging.googleapis.com/local_resource_id" set in the format of
+  # "gke_container.<namespace_id>.<pod_name>.<container_name>".
+  def test_gke_container_logs_kube_env_hidden
+    [1, 2, 3, 5, 11, 50].each do |n|
+      new_stub_context do
+        setup_gce_metadata_stubs
+        setup_container_metadata_stubs_kube_env_hidden
+        setup_metadata_agent_stubs
+        setup_logging_stubs do
+          d = create_driver(ENABLE_METADATA_AGENT_CONFIG)
+          n.times do |i|
+            d.emit(gke_container_log_entry(log_entry(i)))
+          end
+          d.run
+        end
+        verify_log_entries(n, CONTAINER_FROM_APPLICATION_PARAMS)
+        assert_requested_metadata_agent_stub(
+          "#{CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{CONTAINER_NAMESPACE_ID}" \
+          ".#{CONTAINER_POD_NAME}.#{CONTAINER_CONTAINER_NAME}")
+      end
+    end
+  end
+
   private
 
   def stub_metadata_request(metadata_path, response_body)
@@ -1669,10 +1715,10 @@ module BaseTest
                           MANAGED_VM_BACKEND_VERSION)
   end
 
-  def setup_container_metadata_stubs
+  def setup_container_metadata_stubs_common
     stub_metadata_request(
       'instance/attributes/',
-      "attribute1\ncluster-name\ncluster-location\nlast_attribute")
+      "attribute1\ncluster-name\ncluster-location\nkube-env\nlast_attribute")
     stub_metadata_request('instance/attributes/cluster-name',
                           CONTAINER_CLUSTER_NAME)
   end
@@ -1697,14 +1743,30 @@ module BaseTest
     end
   end
 
-  def setup_cloudfunctions_metadata_stubs
+  def setup_cloudfunctions_metadata_stubs_common
     stub_metadata_request(
       'instance/attributes/',
-      "attribute1\ncluster-name\ncluster-location\ngcf_region\nlast_attribute")
+      "attribute1\ncluster-name\ncluster-location\nkube-env\ngcf_region\n"\
+      'last_attribute')
     stub_metadata_request('instance/attributes/cluster-name',
                           CONTAINER_CLUSTER_NAME)
     stub_metadata_request('instance/attributes/gcf_region',
                           CLOUDFUNCTIONS_REGION)
+  end
+
+  def setup_cloudfunctions_metadata_stubs
+    setup_cloudfunctions_metadata_stubs_common
+    stub_metadata_request('instance/attributes/kube-env',
+                          "ENABLE_NODE_LOGGING: \"true\"\n"\
+                          'INSTANCE_PREFIX: '\
+                          "gke-#{CLOUDFUNCTIONS_CLUSTER_NAME}-740fdafa\n"\
+                          'KUBE_BEARER_TOKEN: AoQiMuwkNP2BMT0S')
+  end
+
+  def setup_cloudfunctions_metadata_stubs_kube_env_hidden
+    setup_cloudfunctions_metadata_stubs_common
+    stub_request(:get, 'http://169.254.169.254/computeMetadata/v1/'\
+                 'instance/attributes/kube-env').to_return(status: 403)
   end
 
   def setup_dataproc_metadata_stubs

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1496,8 +1496,9 @@ module BaseTest
         log_entry: k8s_node_log_entry(log_entry(0)),
         expected_params: K8S_NODE_PARAMS
       }
-    ].each do |test_params|
+    ].each do |test_params, index|
       new_stub_context do
+	print index
         setup_gce_metadata_stubs
         setup_metadata_agent_stubs(test_params[:setup_metadata_agent_stub])
         setup_k8s_metadata_stubs(test_params[:setup_k8s_stub])

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1496,9 +1496,8 @@ module BaseTest
         log_entry: k8s_node_log_entry(log_entry(0)),
         expected_params: K8S_NODE_PARAMS
       }
-    ].each do |test_params, index|
+    ].each do |test_params|
       new_stub_context do
-        print index
         setup_gce_metadata_stubs
         setup_metadata_agent_stubs(test_params[:setup_metadata_agent_stub])
         setup_k8s_metadata_stubs(test_params[:setup_k8s_stub])

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1096,27 +1096,6 @@ module BaseTest
     end
   end
 
-  def test_cloudfunctions_log_metadata_concealment
-    setup_gce_metadata_stubs
-    setup_cloudfunctions_metadata_stubs_kube_env_hidden
-    [1, 2, 3, 5, 11, 50].each do |n|
-      setup_logging_stubs do
-        d = create_driver(APPLICATION_DEFAULT_CONFIG, CLOUDFUNCTIONS_TAG)
-        # The test driver doesn't clear its buffer of entries after running, so
-        # do it manually here.
-        d.instance_variable_get('@entries').clear
-        @logs_sent = []
-        n.times { |i| d.emit(cloudfunctions_log_entry(i)) }
-        d.run
-      end
-      verify_log_entries(n, CLOUDFUNCTIONS_PARAMS) do |entry, i|
-        verify_default_log_entry_text(entry['textPayload'], i, entry)
-        assert_equal 'DEBUG', entry['severity'],
-                     "Test with #{n} logs failed. \n#{entry}"
-      end
-    end
-  end
-
   def test_dataproc_log
     setup_gce_metadata_stubs
     setup_dataproc_metadata_stubs
@@ -1622,12 +1601,6 @@ module BaseTest
                  metadata_path)
       .to_return(body: response_body, status: 200,
                  headers: { 'Content-Length' => response_body.length })
-  end
-
-  def stub_metadata_request_permission_denied(metadata_path)
-    stub_request(:get, 'http://169.254.169.254/computeMetadata/v1/' +
-                 metadata_path)
-      .to_return(status: 403)
   end
 
   def setup_no_metadata_service_stubs

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -143,20 +143,11 @@ module Constants
     ".#{K8S_CONTAINER_NAME}".freeze
 
   # Container Engine / Kubernetes specific labels.
-  CONTAINER_CLUSTER_NAME = 'cluster-1'.freeze
   CONTAINER_NAMESPACE_ID = '898268c8-4a36-11e5-9d81-42010af0194c'.freeze
-  CONTAINER_NAMESPACE_NAME = 'kube-system'.freeze
   CONTAINER_POD_ID = 'cad3c3c4-4b9c-11e5-9d81-42010af0194c'.freeze
-  CONTAINER_POD_NAME = 'redis-master-c0l82.foo.bar'.freeze
-  CONTAINER_CONTAINER_NAME = 'redis'.freeze
   CONTAINER_LABEL_KEY = 'component'.freeze
   CONTAINER_LABEL_VALUE = 'redis-component'.freeze
-  CONTAINER_STREAM = 'stdout'.freeze
   CONTAINER_SEVERITY = 'INFO'.freeze
-  # Timestamp for 1234567890 seconds and 987654321 nanoseconds since epoch.
-  CONTAINER_TIMESTAMP = '2009-02-13T23:31:30.987654321Z'.freeze
-  CONTAINER_SECONDS_EPOCH = 1_234_567_890
-  CONTAINER_NANOS = 987_654_321
   CONTAINER_LOCAL_RESOURCE_ID_PREFIX = 'gke_container'.freeze
 
   # Cloud Functions specific labels.
@@ -408,28 +399,27 @@ module Constants
 
   # GKE Container.
   CONTAINER_TAG =
-    "kubernetes.#{CONTAINER_POD_NAME}_#{CONTAINER_NAMESPACE_NAME}_" \
-    "#{CONTAINER_CONTAINER_NAME}".freeze
+    "kubernetes.#{K8S_POD_NAME}_#{K8S_NAMESPACE_NAME}_" \
+    "#{K8S_CONTAINER_NAME}".freeze
 
   CONTAINER_FROM_METADATA_PARAMS = {
     resource: {
       type: GKE_CONSTANTS[:resource_type],
       labels: {
-        'cluster_name' => CONTAINER_CLUSTER_NAME,
+        'cluster_name' => K8S_CLUSTER_NAME,
         'namespace_id' => CONTAINER_NAMESPACE_ID,
         'instance_id' => VM_ID,
         'pod_id' => CONTAINER_POD_ID,
-        'container_name' => CONTAINER_CONTAINER_NAME,
+        'container_name' => K8S_CONTAINER_NAME,
         'zone' => ZONE
       }
     },
-    log_name: CONTAINER_CONTAINER_NAME,
+    log_name: K8S_CONTAINER_NAME,
     project_id: PROJECT_ID,
     labels: {
-      "#{GKE_CONSTANTS[:service]}/namespace_name" =>
-        CONTAINER_NAMESPACE_NAME,
-      "#{GKE_CONSTANTS[:service]}/pod_name" => CONTAINER_POD_NAME,
-      "#{GKE_CONSTANTS[:service]}/stream" => CONTAINER_STREAM,
+      "#{GKE_CONSTANTS[:service]}/namespace_name" => K8S_NAMESPACE_NAME,
+      "#{GKE_CONSTANTS[:service]}/pod_name" => K8S_POD_NAME,
+      "#{GKE_CONSTANTS[:service]}/stream" => K8S_STREAM,
       "label/#{CONTAINER_LABEL_KEY}" => CONTAINER_LABEL_VALUE,
       "#{COMPUTE_CONSTANTS[:service]}/resource_name" => HOSTNAME
     }
@@ -441,21 +431,20 @@ module Constants
     resource: {
       type: GKE_CONSTANTS[:resource_type],
       labels: {
-        'cluster_name' => CONTAINER_CLUSTER_NAME,
-        'namespace_id' => CONTAINER_NAMESPACE_NAME,
+        'cluster_name' => K8S_CLUSTER_NAME,
+        'namespace_id' => K8S_NAMESPACE_NAME,
         'instance_id' => VM_ID,
-        'pod_id' => CONTAINER_POD_NAME,
-        'container_name' => CONTAINER_CONTAINER_NAME,
+        'pod_id' => K8S_POD_NAME,
+        'container_name' => K8S_CONTAINER_NAME,
         'zone' => ZONE
       }
     },
-    log_name: CONTAINER_CONTAINER_NAME,
+    log_name: K8S_CONTAINER_NAME,
     project_id: PROJECT_ID,
     labels: {
-      "#{GKE_CONSTANTS[:service]}/namespace_name" =>
-        CONTAINER_NAMESPACE_NAME,
-      "#{GKE_CONSTANTS[:service]}/pod_name" => CONTAINER_POD_NAME,
-      "#{GKE_CONSTANTS[:service]}/stream" => CONTAINER_STREAM,
+      "#{GKE_CONSTANTS[:service]}/namespace_name" => K8S_NAMESPACE_NAME,
+      "#{GKE_CONSTANTS[:service]}/pod_name" => K8S_POD_NAME,
+      "#{GKE_CONSTANTS[:service]}/stream" => K8S_STREAM,
       "#{COMPUTE_CONSTANTS[:service]}/resource_name" => HOSTNAME
     }
   }.freeze
@@ -464,11 +453,11 @@ module Constants
     resource: {
       type: GKE_CONSTANTS[:resource_type],
       labels: {
-        'cluster_name' => CONTAINER_CLUSTER_NAME,
+        'cluster_name' => K8S_CLUSTER_NAME,
         'namespace_id' => CONTAINER_NAMESPACE_ID,
         'instance_id' => VM_ID,
         'pod_id' => CONTAINER_POD_ID,
-        'container_name' => CONTAINER_CONTAINER_NAME,
+        'container_name' => K8S_CONTAINER_NAME,
         'zone' => ZONE
       }
     },
@@ -788,12 +777,12 @@ module Constants
       }.to_json,
     # GKE container logs.
     "#{CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{CONTAINER_NAMESPACE_ID}" \
-    ".#{CONTAINER_POD_NAME}.#{CONTAINER_CONTAINER_NAME}" =>
+    ".#{K8S_POD_NAME}.#{K8S_CONTAINER_NAME}" =>
       {
         'type' => GKE_CONSTANTS[:resource_type],
         'labels' => {
-          'cluster_name' => CONTAINER_CLUSTER_NAME,
-          'container_name' => CONTAINER_CONTAINER_NAME,
+          'cluster_name' => K8S_CLUSTER_NAME,
+          'container_name' => K8S_CONTAINER_NAME,
           'instance_id' => VM_ID,
           'namespace_id' => CONTAINER_NAMESPACE_ID,
           'pod_id' => CONTAINER_POD_ID,


### PR DESCRIPTION
When metadata concealment is enabled, kube-env is not available to pods outside of `hostNetwork`.