### PR TITLE
Upgrade Fluentd to v1.2.5 and bump gem version to v0.7.0.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -10,7 +10,7 @@ eos
   gem.homepage      =
     'https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud'
   gem.license       = 'Apache-2.0'
-  gem.version       = '0.6.25.1'
+  gem.version       = '0.7.0'
   gem.authors       = ['Stackdriver Agents Team']
   gem.email         = ['stackdriver-agents@google.com']
   gem.required_ruby_version = Gem::Requirement.new('>= 2.2')
@@ -19,7 +19,7 @@ eos
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'fluentd', '~> 0.10'
+  gem.add_runtime_dependency 'fluentd', '~> 1.2', '>= 1.2.5'
   gem.add_runtime_dependency 'googleapis-common-protos', '~> 1.3'
   gem.add_runtime_dependency 'google-api-client', '~> 0.17'
   gem.add_runtime_dependency 'google-cloud-logging', '~> 1.3', '>= 1.3.2'


### PR DESCRIPTION
Upgrade Fluentd to v1.2.5 (latest as of Aug 24, 2018) to apply this fix https://github.com/fluent/fluentd/issues/1941.
Fixes #251.