### PR TITLE
Fix cascading JSON detection with LogEntry fields.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 1500
 Metrics/ModuleLength:
-  Max: 1850
+  Max: 2000
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -600,8 +600,8 @@ module Fluent
               # Extract LogEntry fields if they are present in the nested JSON.
               # This will take precedence of the root level values.
             end
-            # Restore these if necessary. Note that we don't
-            # want to override these keys in the JSON we've just parsed.
+            # Restore these if necessary. Note that we don't want to override
+            # these keys in the JSON we've just parsed.
             record['time'] ||= timestamp if timestamp
             record['severity'] ||= severity if severity
             record[@trace_key] ||= trace if trace

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -602,6 +602,11 @@ module Fluent
             unless record_json.nil?
               record = record_json
               is_json = true
+              # Extract LogEntry fields if they are present in the nested JSON.
+              # This will take precedence of the root level values.
+              fq_trace_id ||= record.delete(@trace_key)
+              span_id ||= record.delete(@span_id_key)
+              insert_id ||= record.delete(@insert_id_key)
             end
             # Restore timestamp and severity if necessary. Note that we don't
             # want to override these keys in the JSON we've just parsed.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -597,8 +597,6 @@ module Fluent
             unless record_json.nil?
               record = record_json
               is_json = true
-              # Extract LogEntry fields if they are present in the nested JSON.
-              # This will take precedence of the root level values.
             end
             # Restore these if necessary. Note that we don't want to override
             # these keys in the JSON we've just parsed.
@@ -620,11 +618,12 @@ module Fluent
                                             ts_secs,
                                             ts_nanos)
 
-          entry.trace = record.delete(@trace_key) if record.key?(@trace_key)
-          entry.span_id = record.delete(@span_id_key) if
-            record.key?(@span_id_key)
-          entry.insert_id = record.delete(@insert_id_key) if
-            record.key?(@insert_id_key)
+          trace = record.delete(@trace_key)
+          entry.trace = trace if trace
+          span_id = record.delete(@span_id_key)
+          entry.span_id = span_id if span_id
+          insert_id = record.delete(@insert_id_key)
+          entry.insert_id = insert_id if insert_id
 
           set_log_entry_fields(record, entry)
           set_payload(entry_level_resource.type, record, entry, is_json)

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -577,7 +577,7 @@ module Fluent
           # record so that cascading JSON detection happens (we rely on the
           # record having only 1 field to trigger the detection). These will be
           # set later in the LogEntry.
-          fq_trace_id = record.delete(@trace_key)
+          trace_id = record.delete(@trace_key)
           span_id = record.delete(@span_id_key)
           insert_id = record.delete(@insert_id_key)
 
@@ -604,9 +604,10 @@ module Fluent
               is_json = true
               # Extract LogEntry fields if they are present in the nested JSON.
               # This will take precedence of the root level values.
-              fq_trace_id ||= record.delete(@trace_key)
-              span_id ||= record.delete(@span_id_key)
-              insert_id ||= record.delete(@insert_id_key)
+              trace_id = record.delete(@trace_key) if record.key?(@trace_key)
+              span_id = record.delete(@span_id_key) if record.key?(@span_id_key)
+              insert_id = record.delete(@insert_id_key) if
+                record.key?(@insert_id_key)
             end
             # Restore timestamp and severity if necessary. Note that we don't
             # want to override these keys in the JSON we've just parsed.
@@ -625,7 +626,7 @@ module Fluent
                                             ts_secs,
                                             ts_nanos)
 
-          entry.trace = fq_trace_id if fq_trace_id
+          entry.trace = trace_id if trace_id
           entry.span_id = span_id if span_id
           entry.insert_id = insert_id if insert_id
 

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -573,7 +573,6 @@ module Fluent
             determine_entry_level_monitored_resource_and_labels(
               group_level_resource, group_level_common_labels, record)
 
-
           is_json = false
           if @detect_json
             # Save the following fields if available, then clear them out to

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -573,6 +573,14 @@ module Fluent
             determine_entry_level_monitored_resource_and_labels(
               group_level_resource, group_level_common_labels, record)
 
+          # Preserve traceId, spanId and insertId. Remove them from the log
+          # record so that cascading JSON detection happens (we rely on the
+          # record having only 1 field to trigger the detection). These will be
+          # set later in the LogEntry.
+          fq_trace_id = record.delete(@trace_key)
+          span_id = record.delete(@span_id_key)
+          insert_id = record.delete(@insert_id_key)
+
           is_json = false
           if @detect_json
             # Save the timestamp and severity if available, then clear it out to
@@ -612,14 +620,8 @@ module Fluent
                                             ts_secs,
                                             ts_nanos)
 
-          # Get fully-qualified trace id for LogEntry "trace" field.
-          fq_trace_id = record.delete(@trace_key)
           entry.trace = fq_trace_id if fq_trace_id
-
-          span_id = record.delete(@span_id_key)
           entry.span_id = span_id if span_id
-
-          insert_id = record.delete(@insert_id_key)
           entry.insert_id = insert_id if insert_id
 
           set_log_entry_fields(record, entry)

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -98,6 +98,11 @@ module Constants
   MANAGED_VM_BACKEND_NAME = 'default'.freeze
   MANAGED_VM_BACKEND_VERSION = 'guestbook2.0'.freeze
 
+  # LogEntry fields for extraction.
+  TRACE = 'projects/proj1/traces/1234567890abcdef1234567890abcdef'.freeze
+  SPAN_ID = '000000000000004a'.freeze
+  INSERT_ID = 'fah7yr7iw64tg857y'.freeze
+
   # Docker Container labels.
   DOCKER_CONTAINER_ID =
     '0d0f03ff8d3c42688692536d1af77a28cd135c0a5c531f25a31'.freeze

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -100,8 +100,11 @@ module Constants
 
   # LogEntry fields for extraction.
   TRACE = 'projects/proj1/traces/1234567890abcdef1234567890abcdef'.freeze
+  TRACE2 = 'projects/proj1/traces/1234567890abcdef1234567890fedcba'.freeze
   SPAN_ID = '000000000000004a'.freeze
+  SPAN_ID2 = '000000000000007e'.freeze
   INSERT_ID = 'fah7yr7iw64tg857y'.freeze
+  INSERT_ID2 = 'fah7yr7iw64tgaeuf'.freeze
 
   # Docker Container labels.
   DOCKER_CONTAINER_ID =


### PR DESCRIPTION
Today nested JSON detection only happens when the record has one field named "log", "message", "msg". The size of the hash matters.

https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/8d26465c0f777a42938e3acae857936627a38511/lib/fluent/plugin/out_google_cloud.rb#L588

Fields like `logging.googleapis.com/trace`, `logging.googleapis.com/spanId` and `logging.googleapis.com/insertId` should not count towards the hash size when determining whether to extract JSON from the nested field.