### PR TITLE
Extract the gem version by looking for the current file.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -228,8 +228,16 @@ module Fluent
     Fluent::Plugin.register_output('google_cloud', self)
 
     PLUGIN_NAME = 'Fluentd Google Cloud Logging plugin'.freeze
-    PLUGIN_VERSION = \
-      Gem.loaded_specs['fluent-plugin-google-cloud'].version.to_s.freeze
+    # Extract plugin version by finding the spec this file was loaded from.
+    PLUGIN_VERSION = begin
+      dependency = Gem::Dependency.new('fluent-plugin-google-cloud')
+      all_specs, = Gem::SpecFetcher.fetcher.spec_for_dependency(dependency)
+      matching_spec, = all_specs.grep(
+        proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
+          spec.version.to_s
+        end
+      matching_spec
+    end.freeze
 
     # Name of the the Google cloud logging write scope.
     LOGGING_SCOPE = 'https://www.googleapis.com/auth/logging.write'.freeze


### PR DESCRIPTION
A follow-on to #245. That solution didn't work because the gem wasn't always loaded.