### PR TITLE
Use Fluentd v0.12 compatible module path.

### DIFF
--- a/lib/fluent/plugin/filter_add_insert_ids.rb
+++ b/lib/fluent/plugin/filter_add_insert_ids.rb
@@ -12,92 +12,88 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'fluent/plugin/filter'
-
 module Fluent
-  module Plugin
-    # Fluentd filter plugin for adding insertIds to guarantee log entry order
-    # and uniqueness.
-    # Sample log entries enriched by this plugin:
-    # {
-    #   "timestamp": "2017-08-22 13:35:28",
-    #   "message": "1",
-    #   "logging.googleapis.com/insertId": "aye7eakuf23h41aef0"
-    # }
-    # {
-    #   "timestamp": "2017-08-22 13:35:28",
-    #   "message": "2",
-    #   "logging.googleapis.com/insertId": "aye7eakuf23h41aef1"
-    # }
-    # {
-    #   "timestamp": "2017-08-22 13:35:28",
-    #   "message": "3",
-    #   "logging.googleapis.com/insertId": "aye7eakuf23h41aef2"
-    # }
-    class AddInsertIdsFilter < Filter
-      Fluent::Plugin.register_filter('add_insert_ids', self)
+  # Fluentd filter plugin for adding insertIds to guarantee log entry order
+  # and uniqueness.
+  # Sample log entries enriched by this plugin:
+  # {
+  #   "timestamp": "2017-08-22 13:35:28",
+  #   "message": "1",
+  #   "logging.googleapis.com/insertId": "aye7eakuf23h41aef0"
+  # }
+  # {
+  #   "timestamp": "2017-08-22 13:35:28",
+  #   "message": "2",
+  #   "logging.googleapis.com/insertId": "aye7eakuf23h41aef1"
+  # }
+  # {
+  #   "timestamp": "2017-08-22 13:35:28",
+  #   "message": "3",
+  #   "logging.googleapis.com/insertId": "aye7eakuf23h41aef2"
+  # }
+  class AddInsertIdsFilter < Filter
+    Fluent::Plugin.register_filter('add_insert_ids', self)
 
-      # Constants for configuration.
-      module ConfigConstants
-        # The default field name of insertIds in the log entry.
-        DEFAULT_INSERT_ID_KEY = 'logging.googleapis.com/insertId'.freeze
-        # The character size of the insertIds. This matches the setup in the
-        # Stackdriver Logging backend.
-        INSERT_ID_SIZE = 17
-        # The characters that are allowed in the insertIds. This matches the
-        # allowed collection by the Stackdriver Logging Backend.
-        ALLOWED_CHARS = (Array(0..9) + Array('a'..'z')).freeze
+    # Constants for configuration.
+    module ConfigConstants
+      # The default field name of insertIds in the log entry.
+      DEFAULT_INSERT_ID_KEY = 'logging.googleapis.com/insertId'.freeze
+      # The character size of the insertIds. This matches the setup in the
+      # Stackdriver Logging backend.
+      INSERT_ID_SIZE = 17
+      # The characters that are allowed in the insertIds. This matches the
+      # allowed collection by the Stackdriver Logging Backend.
+      ALLOWED_CHARS = (Array(0..9) + Array('a'..'z')).freeze
+    end
+
+    include self::ConfigConstants
+
+    desc 'The field name for insertIds in the log record.'
+    config_param :insert_id_key, :string, default: DEFAULT_INSERT_ID_KEY
+
+    # Expose attr_readers for testing.
+    attr_reader :insert_id_key
+
+    def start
+      super
+      @log = $log # rubocop:disable Style/GlobalVars
+
+      # Initialize the insertID.
+      @log.info "Started the add_insert_ids plugin with #{@insert_id_key}" \
+                ' as the insert ID key.'
+      @insert_id = generate_initial_insert_id
+      @log.info "Initialized the insert ID key to #{@insert_id}."
+    end
+
+    def configure(conf)
+      super
+    end
+
+    def shutdown
+      super
+    end
+
+    # rubocop:disable Style/UnusedMethodArgument
+    def filter(tag, time, record)
+      # Only generate and add an insertId field if the record is a hash and
+      # the insert ID field is not already set (or set to an empty string).
+      if record.is_a?(Hash) && record[@insert_id_key].to_s.empty?
+        record[@insert_id_key] = increment_insert_id
       end
+      record
+    end
+    # rubocop:enable Style/UnusedMethodArgument
 
-      include self::ConfigConstants
+    private
 
-      desc 'The field name for insertIds in the log record.'
-      config_param :insert_id_key, :string, default: DEFAULT_INSERT_ID_KEY
+    # Generate a random string as the initial insertId.
+    def generate_initial_insert_id
+      Array.new(INSERT_ID_SIZE) { ALLOWED_CHARS.sample }.join
+    end
 
-      # Expose attr_readers for testing.
-      attr_reader :insert_id_key
-
-      def start
-        super
-        @log = $log # rubocop:disable Style/GlobalVars
-
-        # Initialize the insertID.
-        @log.info "Started the add_insert_ids plugin with #{@insert_id_key}" \
-                  ' as the insert ID key.'
-        @insert_id = generate_initial_insert_id
-        @log.info "Initialized the insert ID key to #{@insert_id}."
-      end
-
-      def configure(conf)
-        super
-      end
-
-      def shutdown
-        super
-      end
-
-      # rubocop:disable Style/UnusedMethodArgument
-      def filter(tag, time, record)
-        # Only generate and add an insertId field if the record is a hash and
-        # the insert ID field is not already set (or set to an empty string).
-        if record.is_a?(Hash) && record[@insert_id_key].to_s.empty?
-          record[@insert_id_key] = increment_insert_id
-        end
-        record
-      end
-      # rubocop:enable Style/UnusedMethodArgument
-
-      private
-
-      # Generate a random string as the initial insertId.
-      def generate_initial_insert_id
-        Array.new(INSERT_ID_SIZE) { ALLOWED_CHARS.sample }.join
-      end
-
-      # Increment the insertId and return the new value.
-      def increment_insert_id
-        @insert_id = @insert_id.next
-      end
+    # Increment the insertId and return the new value.
+    def increment_insert_id
+      @insert_id = @insert_id.next
     end
   end
 end

--- a/test/plugin/test_filter_add_insert_ids.rb
+++ b/test/plugin/test_filter_add_insert_ids.rb
@@ -19,7 +19,7 @@ require 'fluent/plugin/filter_add_insert_ids'
 
 # Unit tests for filter_add_insert_ids plugin.
 class FilterAddInsertIdsTest < Test::Unit::TestCase
-  include Fluent::Plugin::AddInsertIdsFilter::ConfigConstants
+  include Fluent::AddInsertIdsFilter::ConfigConstants
 
   CUSTOM_INSERT_ID_KEY = 'custom_insert_id_key'.freeze
   INSERT_ID = 'aeyr82r92h249gh9h'.freeze
@@ -123,7 +123,7 @@ class FilterAddInsertIdsTest < Test::Unit::TestCase
 
   def create_driver(conf = APPLICATION_DEFAULT_CONFIG)
     Fluent::Test::FilterTestDriver.new(
-      Fluent::Plugin::AddInsertIdsFilter).configure(conf, true)
+      Fluent::AddInsertIdsFilter).configure(conf, true)
   end
 
   def log_entry(index)


### PR DESCRIPTION
Change `Fluent::Plugin::AddInsertIdsFilter` to `Fluent::AddInsertIdsFilter`.

Option 1:
Merge in this PR.
Option 2:
Abandon this PR. Instead revert the new add_insert_ids plugin, do a release without it. Upgrade to Fluentd v1.2 then and release add_insert_ids plugin in the next release.
Option 3:
Abandon this PR. Instead Merge the Fluentd v1.2 upgrade (https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/240) now that includes marking Fluentd v1.2 as a dependency.