### PR TITLE
Use file path regex to determine current gem version.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -235,7 +235,7 @@ module Fluent
     PLUGIN_NAME = 'Fluentd Google Cloud Logging plugin'.freeze
     # Extract plugin version by finding the spec this file was loaded from.
     PLUGIN_VERSION = __FILE__.match(
-      %r{fluent-plugin-google-cloud(?<version>[-0-9a-zA-Z\.]*)/})['version']
+      %r{fluent-plugin-google-cloud-?(?<version>[0-9a-zA-Z\.]*)/})['version']
 
     # Name of the the Google cloud logging write scope.
     LOGGING_SCOPE = 'https://www.googleapis.com/auth/logging.write'.freeze

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -242,11 +242,11 @@ module Fluent
       # Extract plugin version by finding the spec this file was loaded from.
       dependency = Gem::Dependency.new('fluent-plugin-google-cloud')
       all_specs, = Gem::SpecFetcher.fetcher.spec_for_dependency(dependency)
-      matching_spec, = all_specs.grep(
-         proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
-           spec.version.to_s
-         end
-      matching_spec
+      matching_version, = all_specs.grep(
+        proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
+          spec.version.to_s
+        end
+      matching_version
     end.freeze
 
     # Name of the the Google cloud logging write scope.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -234,15 +234,8 @@ module Fluent
 
     PLUGIN_NAME = 'Fluentd Google Cloud Logging plugin'.freeze
     # Extract plugin version by finding the spec this file was loaded from.
-    PLUGIN_VERSION = begin
-      dependency = Gem::Dependency.new('fluent-plugin-google-cloud')
-      all_specs, = Gem::SpecFetcher.fetcher.spec_for_dependency(dependency)
-      matching_spec, = all_specs.grep(
-        proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
-          spec.version.to_s
-        end
-      matching_spec
-    end.freeze
+    PLUGIN_VERSION = __FILE__.match(
+      %r{fluent-plugin-google-cloud(?<version>[-0-9a-zA-Z\.]*)/})['version']
 
     # Name of the the Google cloud logging write scope.
     LOGGING_SCOPE = 'https://www.googleapis.com/auth/logging.write'.freeze

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -238,15 +238,18 @@ module Fluent
       # Extract plugin version from file path.
       match_data = __FILE__.match(
         %r{fluent-plugin-google-cloud-(?<version>[0-9a-zA-Z\.]*)/})
-      return match_data['version'] if match_data
-      # Extract plugin version by finding the spec this file was loaded from.
-      dependency = Gem::Dependency.new('fluent-plugin-google-cloud')
-      all_specs, = Gem::SpecFetcher.fetcher.spec_for_dependency(dependency)
-      matching_version, = all_specs.grep(
-        proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
-          spec.version.to_s
-        end
-      matching_version
+      if match_data
+        match_data['version']
+      else
+        # Extract plugin version by finding the spec this file was loaded from.
+        dependency = Gem::Dependency.new('fluent-plugin-google-cloud')
+        all_specs, = Gem::SpecFetcher.fetcher.spec_for_dependency(dependency)
+        matching_version, = all_specs.grep(
+          proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
+            spec.version.to_s
+          end
+        matching_version
+      end
     end.freeze
 
     # Name of the the Google cloud logging write scope.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -233,18 +233,19 @@ module Fluent
     Fluent::Plugin.register_output('google_cloud', self)
 
     PLUGIN_NAME = 'Fluentd Google Cloud Logging plugin'.freeze
+
     PLUGIN_VERSION = begin
       # Extract plugin version from file path.
-      __FILE__.match(
-        %r{fluent-plugin-google-cloud-(?<version>[0-9a-zA-Z\.]*)/})['version']
-    rescue StandardError
+      match_data = __FILE__.match(
+        %r{fluent-plugin-google-cloud-(?<version>[0-9a-zA-Z\.]*)/})
+      return match_data['version'] if match_data
       # Extract plugin version by finding the spec this file was loaded from.
       dependency = Gem::Dependency.new('fluent-plugin-google-cloud')
       all_specs, = Gem::SpecFetcher.fetcher.spec_for_dependency(dependency)
       matching_spec, = all_specs.grep(
-        proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
-          spec.version.to_s
-        end
+         proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
+           spec.version.to_s
+         end
       matching_spec
     end.freeze
 


### PR DESCRIPTION
Turned out the original implementation caused memory usage regression.