### PR TITLE
Add field extraction for httpRequest.serverIp.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -186,6 +186,7 @@ module Fluent
             %w(responseSize response_size parse_int),
             %w(userAgent user_agent parse_string),
             %w(remoteIp remote_ip parse_string),
+            %w(serverIp server_ip parse_string),
             %w(referer referer parse_string),
             %w(cacheHit cache_hit parse_bool),
             %w(cacheValidatedWithOriginServer

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -748,6 +748,7 @@ module Constants
     'responseSize' => 65,
     'userAgent' => 'USER AGENT 1.0',
     'remoteIp' => '55.55.55.55',
+    'serverIp' => '66.66.66.66',
     'referer' => 'http://referer/',
     'cacheHit' => true,
     'cacheValidatedWithOriginServer' => true


### PR DESCRIPTION
Currently server IP is not extracted correctly, resulting in log entry like below:

```
{
 httpRequest: {
  requestMethod:  "GET"   
  requestSize:  "777"   
  requestUrl:  "/"   
  status:  200   
  userAgent:  "Opera/12.0"   
 }
 jsonPayload: {
  httpRequest: {
   serverIp:  "192.168.0.1"    
  }
  ...
 }
 ...
}
```