### PR TITLE
 Add cache_fill_bytes, cache_lookup and protocol field extraction from httpRequest.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -179,19 +179,19 @@ module Fluent
           # Map from subfields' names to their types.
           [
             # subfield key in the payload, destination key, cast lambda (opt)
-            %w(requestMethod request_method parse_string),
-            %w(requestUrl request_url parse_string),
-            %w(requestSize request_size parse_int),
-            %w(status status parse_int),
-            %w(responseSize response_size parse_int),
-            %w(userAgent user_agent parse_string),
-            %w(remoteIp remote_ip parse_string),
-            %w(serverIp server_ip parse_string),
-            %w(referer referer parse_string),
             %w(cacheHit cache_hit parse_bool),
             %w(cacheValidatedWithOriginServer
                cache_validated_with_origin_server parse_bool),
-            %w(latency latency parse_latency)
+            %w(latency latency parse_latency),
+            %w(referer referer parse_string),
+            %w(remoteIp remote_ip parse_string),
+            %w(responseSize response_size parse_int),
+            %w(requestMethod request_method parse_string),
+            %w(requestSize request_size parse_int),
+            %w(requestUrl request_url parse_string),
+            %w(serverIp server_ip parse_string),
+            %w(status status parse_int),
+            %w(userAgent user_agent parse_string)
           ],
           # The grpc version class name.
           'Google::Logging::Type::HttpRequest',

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -179,10 +179,13 @@ module Fluent
           # Map from subfields' names to their types.
           [
             # subfield key in the payload, destination key, cast lambda (opt)
+            %w(cacheFillBytes cache_fill_bytes parse_int),
             %w(cacheHit cache_hit parse_bool),
+            %w(cacheLookup cache_lookup parse_bool),
             %w(cacheValidatedWithOriginServer
                cache_validated_with_origin_server parse_bool),
             %w(latency latency parse_latency),
+            %w(protocol protocol parse_string),
             %w(referer referer parse_string),
             %w(remoteIp remote_ip parse_string),
             %w(responseSize response_size parse_int),

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -741,8 +741,12 @@ module Constants
   ).freeze
 
   HTTP_REQUEST_MESSAGE = {
+    'cacheFillBytes' => 6653,
     'cacheHit' => true,
+    'cacheLookup' => true,
     'cacheValidatedWithOriginServer' => true,
+    'latency' => '3.5s',
+    'protocol' => 'HTTP/1.1',
     'referer' => 'http://referer/',
     'remoteIp' => '55.55.55.55',
     'responseSize' => 65,

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -741,17 +741,17 @@ module Constants
   ).freeze
 
   HTTP_REQUEST_MESSAGE = {
-    'requestMethod' => 'POST',
-    'requestUrl' => 'http://example/',
-    'requestSize' => 210,
-    'status' => 200,
-    'responseSize' => 65,
-    'userAgent' => 'USER AGENT 1.0',
-    'remoteIp' => '55.55.55.55',
-    'serverIp' => '66.66.66.66',
-    'referer' => 'http://referer/',
     'cacheHit' => true,
-    'cacheValidatedWithOriginServer' => true
+    'cacheValidatedWithOriginServer' => true,
+    'referer' => 'http://referer/',
+    'remoteIp' => '55.55.55.55',
+    'responseSize' => 65,
+    'requestMethod' => 'POST',
+    'requestSize' => 210,
+    'requestUrl' => 'http://example/',
+    'serverIp' => '66.66.66.66',
+    'status' => 200,
+    'userAgent' => 'USER AGENT 1.0'
   }.freeze
 
   SOURCE_LOCATION_MESSAGE = {

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -745,7 +745,6 @@ module Constants
     'cacheHit' => true,
     'cacheLookup' => true,
     'cacheValidatedWithOriginServer' => true,
-    'latency' => '3.5s',
     'protocol' => 'HTTP/1.1',
     'referer' => 'http://referer/',
     'remoteIp' => '55.55.55.55',

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -418,11 +418,11 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     ])
   end
 
-  # 'responseSize', 'requestSize' and 'cacheFillBytes' are Integers in the gRPC
+  # 'responseSize', 'requestSize', and 'cacheFillBytes' are Integers in the gRPC
   # protos, yet Strings in REST API client libraries.
   def http_request_message
     convert_subfields_to_strings(
-      HTTP_REQUEST_MESSAGE, %w(responseSize requestSize cacheFillBytes))
+      HTTP_REQUEST_MESSAGE, %w(cacheFillBytes responseSize requestSize))
   end
 
   # 'line' is an Integer in the gRPC proto, yet a String in the REST API client.

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -418,11 +418,11 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     ])
   end
 
-  # 'responseSize' and 'requestSize' are Integers in the gRPC protos, yet
-  # Strings in REST API client libraries.
+  # 'responseSize', 'requestSize' and 'cacheFillBytes' are Integers in the gRPC
+  # protos, yet Strings in REST API client libraries.
   def http_request_message
     convert_subfields_to_strings(
-      HTTP_REQUEST_MESSAGE, %w(responseSize requestSize))
+      HTTP_REQUEST_MESSAGE, %w(responseSize requestSize cacheFillBytes))
   end
 
   # 'line' is an Integer in the gRPC proto, yet a String in the REST API client.


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/issues/271