### PR TITLE
Add more time keys to the preserved keys for json detection

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -614,6 +614,10 @@ module Fluent
             # field.
             preserved_keys = [
               'time',
+              'timeNanos',
+              'timestamp',
+              'timestampNanos',
+              'timestampSeconds',
               'severity',
               @http_request_key,
               @insert_id_key,


### PR DESCRIPTION
Fixes #211. The newly added keys are from considered in function `compute_timestamp`.