### PR TITLE
 Add logEntry->labels auto extraction.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -146,12 +146,12 @@ module Fluent
       # Default values for JSON payload keys to set the "httpRequest",
       # "operation", "sourceLocation", "trace" fields in the LogEntry.
       DEFAULT_HTTP_REQUEST_KEY = 'httpRequest'.freeze
+      DEFAULT_INSERT_ID_KEY = 'logging.googleapis.com/insertId'.freeze
       DEFAULT_OPERATION_KEY = 'logging.googleapis.com/operation'.freeze
       DEFAULT_SOURCE_LOCATION_KEY =
         'logging.googleapis.com/sourceLocation'.freeze
-      DEFAULT_TRACE_KEY = 'logging.googleapis.com/trace'.freeze
       DEFAULT_SPAN_ID_KEY = 'logging.googleapis.com/spanId'.freeze
-      DEFAULT_INSERT_ID_KEY = 'logging.googleapis.com/insertId'.freeze
+      DEFAULT_TRACE_KEY = 'logging.googleapis.com/trace'.freeze
 
       DEFAULT_METADATA_AGENT_URL =
         'http://local-metadata-agent.stackdriver.com:8000'.freeze
@@ -204,16 +204,6 @@ module Fluent
           # The non-grpc version class name.
           'Google::Apis::LoggingV2::HttpRequest'
         ],
-        'source_location' => [
-          '@source_location_key',
-          [
-            %w(file file parse_string),
-            %w(function function parse_string),
-            %w(line line parse_int)
-          ],
-          'Google::Logging::V2::LogEntrySourceLocation',
-          'Google::Apis::LoggingV2::LogEntrySourceLocation'
-        ],
         'operation' => [
           '@operation_key',
           [
@@ -224,6 +214,16 @@ module Fluent
           ],
           'Google::Logging::V2::LogEntryOperation',
           'Google::Apis::LoggingV2::LogEntryOperation'
+        ],
+        'source_location' => [
+          '@source_location_key',
+          [
+            %w(file file parse_string),
+            %w(function function parse_string),
+            %w(line line parse_int)
+          ],
+          'Google::Logging::V2::LogEntrySourceLocation',
+          'Google::Apis::LoggingV2::LogEntrySourceLocation'
         ]
       }.freeze
 
@@ -298,12 +298,12 @@ module Fluent
     # Map keys from a JSON payload to corresponding LogEntry fields.
     config_param :http_request_key, :string, :default =>
       DEFAULT_HTTP_REQUEST_KEY
+    config_param :insert_id_key, :string, :default => DEFAULT_INSERT_ID_KEY
     config_param :operation_key, :string, :default => DEFAULT_OPERATION_KEY
     config_param :source_location_key, :string, :default =>
       DEFAULT_SOURCE_LOCATION_KEY
-    config_param :trace_key, :string, :default => DEFAULT_TRACE_KEY
     config_param :span_id_key, :string, :default => DEFAULT_SPAN_ID_KEY
-    config_param :insert_id_key, :string, :default => DEFAULT_INSERT_ID_KEY
+    config_param :trace_key, :string, :default => DEFAULT_TRACE_KEY
 
     # Whether to try to detect if the record is a text log entry with JSON
     # content that needs to be parsed.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1697,6 +1697,10 @@ module Fluent
     end
 
     def set_log_entry_fields(record, entry)
+      # TODO(qingling128) On the next major after 0.7.4, make all logEntry
+      # subfields behave the same way: if the field is not in the correct
+      # format, log an error in the Fluentd log and remove this field from
+      # payload. This is the preferred behavior per PM decision.
       LOG_ENTRY_FIELDS_MAP.each do |field_name, config|
         payload_key, subfields, grpc_class, non_grpc_class = config
         begin

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1745,13 +1745,13 @@ module Fluent
       payload_labels = record.delete(@labels_key)
       unless payload_labels.is_a?(Hash)
         @log.error "Invalid value of '#{@labels_key}' in the payload: " \
-                   "#{payload_labels}. Labels need to be a JSON object.", err
+                   "#{payload_labels}. Labels need to be a JSON object."
         return nil
       end
       payload_labels.each do |k, v|
         next if k.is_a?(String) && v.is_a?(String)
-        @log.error "Invalid value of '#{@labels_key}' in the payload. " \
-                   "#{payload_labels}. Labels need to have string values.", err
+        @log.error "Invalid value of '#{@labels_key}' in the payload: " \
+                   "#{payload_labels}. Labels need to have string values."
         return nil
       end
       payload_labels

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1743,6 +1743,7 @@ module Fluent
     # Parse labels. Return nil if not set.
     def parse_labels(record)
       payload_labels = record.delete(@labels_key)
+      return nil unless payload_labels
       unless payload_labels.is_a?(Hash)
         @log.error "Invalid value of '#{@labels_key}' in the payload: " \
                    "#{payload_labels}. Labels need to be a JSON object."

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1742,24 +1742,21 @@ module Fluent
 
     # Parse labels. Return nil if not set.
     def parse_labels(record)
-      payload_value = record.delete(@labels_key)
-      unless payload_value.is_a?(Hash)
-        @log.error 'Failed to set log entry field for labels. Labels need ' \
-                   'to be a hash where both keys and values are strings.' \
-                   "\nValue: #{payload_value}."
+      payload_labels = record.delete(@labels_key)
+      unless payload_labels.is_a?(Hash)
+        @log.error "Invalid value of '#{@labels_key}' in the payload: " \
+                   "#{payload_labels}. Labels need to be a JSON object.", err
         return nil
       end
-      payload_value.each do |k, v|
+      payload_labels.each do |k, v|
         next if k.is_a?(String) && v.is_a?(String)
-        @log.error 'Failed to set log entry field for labels. Labels need ' \
-                     'to be a hash where both keys and values are strings.' \
-                     "\nValue: #{payload_value}."
+        @log.error "Invalid value of '#{@labels_key}' in the payload. " \
+                   "#{payload_labels}. Labels need to have string values.", err
         return nil
       end
-      payload_value
+      payload_labels
     rescue StandardError => err
-      @log.error 'Failed to set log entry field for labels.' \
-                 "\nValue: #{payload_value}", err
+      @log.error "Failed to extract '#{@labels_key}' from payload.", err
       return nil
     end
 

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1749,10 +1749,14 @@ module Fluent
                    "#{payload_labels}. Labels need to be a JSON object."
         return nil
       end
-      payload_labels.each do |k, v|
-        next if k.is_a?(String) && v.is_a?(String)
+
+      non_string_keys = payload_labels.each_with_object([]) do |(k, v), a|
+        a << k unless k.is_a?(String) && v.is_a?(String)
+      end
+      unless non_string_keys.empty?
         @log.error "Invalid value of '#{@labels_key}' in the payload: " \
-                   "#{payload_labels}. Labels need to have string values."
+                   "#{payload_labels}. Labels need string values for all " \
+                   "keys; keys #{non_string_keys} don't."
         return nil
       end
       payload_labels

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1249,12 +1249,12 @@ module BaseTest
     verify_subfields_from_record(DEFAULT_HTTP_REQUEST_KEY)
   end
 
-  def test_log_entry_source_location_field_from_record
-    verify_subfields_from_record(DEFAULT_SOURCE_LOCATION_KEY)
-  end
-
   def test_log_entry_operation_field_from_record
     verify_subfields_from_record(DEFAULT_OPERATION_KEY)
+  end
+
+  def test_log_entry_source_location_field_from_record
+    verify_subfields_from_record(DEFAULT_SOURCE_LOCATION_KEY)
   end
 
   # Verify the subfields extraction of LogEntry fields when there are other
@@ -1264,12 +1264,12 @@ module BaseTest
     verify_subfields_partial_from_record(DEFAULT_HTTP_REQUEST_KEY)
   end
 
-  def test_log_entry_source_location_field_partial_from_record
-    verify_subfields_partial_from_record(DEFAULT_SOURCE_LOCATION_KEY)
-  end
-
   def test_log_entry_operation_field_partial_from_record
     verify_subfields_partial_from_record(DEFAULT_OPERATION_KEY)
+  end
+
+  def test_log_entry_source_location_field_partial_from_record
+    verify_subfields_partial_from_record(DEFAULT_SOURCE_LOCATION_KEY)
   end
 
   # Verify the subfields extraction of LogEntry fields when they are not hashes.
@@ -1278,12 +1278,12 @@ module BaseTest
     verify_subfields_when_not_hash(DEFAULT_HTTP_REQUEST_KEY)
   end
 
-  def test_log_entry_source_location_field_when_not_hash
-    verify_subfields_when_not_hash(DEFAULT_SOURCE_LOCATION_KEY)
-  end
-
   def test_log_entry_operation_field_when_not_hash
     verify_subfields_when_not_hash(DEFAULT_OPERATION_KEY)
+  end
+
+  def test_log_entry_source_location_field_when_not_hash
+    verify_subfields_when_not_hash(DEFAULT_SOURCE_LOCATION_KEY)
   end
 
   # Verify the subfields extraction of LogEntry fields when they are nil.
@@ -1292,12 +1292,12 @@ module BaseTest
     verify_subfields_when_nil(DEFAULT_HTTP_REQUEST_KEY)
   end
 
-  def test_log_entry_source_location_field_when_nil
-    verify_subfields_when_nil(DEFAULT_SOURCE_LOCATION_KEY)
-  end
-
   def test_log_entry_operation_field_when_nil
     verify_subfields_when_nil(DEFAULT_OPERATION_KEY)
+  end
+
+  def test_log_entry_source_location_field_when_nil
+    verify_subfields_when_nil(DEFAULT_SOURCE_LOCATION_KEY)
   end
 
   def test_http_request_from_record_with_referer_nil_or_absent
@@ -2242,10 +2242,10 @@ module BaseTest
       # the subfield in LogEntry object and the expected value of that field.
       DEFAULT_HTTP_REQUEST_KEY => [
         'httpRequest', http_request_message],
-      DEFAULT_SOURCE_LOCATION_KEY => [
-        'sourceLocation', source_location_message],
       DEFAULT_OPERATION_KEY => [
-        'operation', OPERATION_MESSAGE]
+        'operation', OPERATION_MESSAGE],
+      DEFAULT_SOURCE_LOCATION_KEY => [
+        'sourceLocation', source_location_message]
     }
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1395,37 +1395,54 @@ module BaseTest
   # Verify the default and customization of LogEntry field extraction key.
 
   def test_log_entry_insert_id_field
-    verify_field_key('insertId', DEFAULT_INSERT_ID_KEY, 'custom_insert_id_key',
-                     CONFIG_CUSTOM_INSERT_ID_KEY_SPECIFIED, INSERT_ID)
+    verify_field_key('insertId',
+                     default_key: DEFAULT_INSERT_ID_KEY,
+                     custom_key: 'custom_insert_id_key',
+                     custom_key_config: CONFIG_CUSTOM_INSERT_ID_KEY_SPECIFIED,
+                     sample_value: INSERT_ID)
   end
 
   def test_log_entry_labels_field
-    verify_field_key('labels', DEFAULT_LABELS_KEY, 'custom_labels_key',
-                     CONFIG_CUSTOM_LABELS_KEY_SPECIFIED,
-                     COMPUTE_PARAMS[:labels].merge(LABELS_MESSAGE),
-                     COMPUTE_PARAMS[:labels])
+    verify_field_key('labels',
+                     default_key: DEFAULT_LABELS_KEY,
+                     custom_key: 'custom_labels_key',
+                     custom_key_config: CONFIG_CUSTOM_LABELS_KEY_SPECIFIED,
+                     sample_value: COMPUTE_PARAMS[:labels].merge(
+                       LABELS_MESSAGE),
+                     default_value: COMPUTE_PARAMS[:labels])
   end
 
   def test_log_entry_operation_field
-    verify_field_key('operation', DEFAULT_OPERATION_KEY, 'custom_operation_key',
-                     CONFIG_CUSTOM_OPERATION_KEY_SPECIFIED, OPERATION_MESSAGE)
+    verify_field_key('operation',
+                     default_key: DEFAULT_OPERATION_KEY,
+                     custom_key: 'custom_operation_key',
+                     custom_key_config: CONFIG_CUSTOM_OPERATION_KEY_SPECIFIED,
+                     sample_value: OPERATION_MESSAGE)
   end
 
   def test_log_entry_source_location_field
-    verify_field_key('sourceLocation', DEFAULT_SOURCE_LOCATION_KEY,
-                     'custom_source_location_key',
-                     CONFIG_CUSTOM_SOURCE_LOCATION_KEY_SPECIFIED,
-                     source_location_message)
+    verify_field_key('sourceLocation',
+                     default_key: DEFAULT_SOURCE_LOCATION_KEY,
+                     custom_key: 'custom_source_location_key',
+                     custom_key_config: \
+                       CONFIG_CUSTOM_SOURCE_LOCATION_KEY_SPECIFIED,
+                     sample_value: source_location_message)
   end
 
   def test_log_entry_span_id_field
-    verify_field_key('spanId', DEFAULT_SPAN_ID_KEY, 'custom_span_id_key',
-                     CONFIG_CUSTOM_SPAN_ID_KEY_SPECIFIED, SPAN_ID)
+    verify_field_key('spanId',
+                     default_key: DEFAULT_SPAN_ID_KEY,
+                     custom_key: 'custom_span_id_key',
+                     custom_key_config: CONFIG_CUSTOM_SPAN_ID_KEY_SPECIFIED,
+                     sample_value: SPAN_ID)
   end
 
   def test_log_entry_trace_field
-    verify_field_key('trace', DEFAULT_TRACE_KEY, 'custom_trace_key',
-                     CONFIG_CUSTOM_TRACE_KEY_SPECIFIED, TRACE)
+    verify_field_key('trace',
+                     default_key: DEFAULT_TRACE_KEY,
+                     custom_key: 'custom_trace_key',
+                     custom_key_config: CONFIG_CUSTOM_TRACE_KEY_SPECIFIED,
+                     sample_value: TRACE)
   end
 
   # Verify the cascading JSON detection of LogEntry fields.
@@ -2552,8 +2569,13 @@ module BaseTest
     end
   end
 
-  def verify_field_key(log_entry_field, default_key, custom_key,
-                       custom_key_config, sample_value, default_value = nil)
+  def verify_field_key(log_entry_field, test_params)
+    default_key = test_params[:default_key]
+    custom_key = test_params[:custom_key]
+    custom_key_config = test_params[:custom_key_config]
+    sample_value = test_params[:sample_value]
+    default_value = test_params.fetch(:default_value, nil)
+
     setup_gce_metadata_stubs
     message = log_entry(0)
     [

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -2437,7 +2437,6 @@ module BaseTest
     end
   end
 
-  # Verify that we remove the malformed field.
   def verify_subfields_removed_when_not_hash(payload_key)
     destination_key = log_entry_subfields_params[payload_key][0]
     @logs_sent = []
@@ -2456,7 +2455,6 @@ module BaseTest
     end
   end
 
-  # Verify that we leave the malformed field as it is.
   def verify_subfields_untouched_when_not_hash(payload_key)
     destination_key = log_entry_subfields_params[payload_key][0]
     @logs_sent = []
@@ -2467,6 +2465,7 @@ module BaseTest
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      # Verify that we leave the malformed field as it is.
       field = get_fields(entry['jsonPayload'])[payload_key]
       assert_equal 'a_string', get_string(field), entry
       assert_false entry.key?(destination_key), entry

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1271,7 +1271,7 @@ module BaseTest
   end
 
   # We don't need a test like 'test_log_entry_labels_field_partial_from_record'
-  # becasue labels are free range strings. Everything in the labels field should
+  # because labels are free range strings. Everything in the labels field should
   # be in the resulting logEntry->labels field. There is no need to check
   # partial transformation (aka, some 'labels' fields are extracted, while
   # others are left as it is).

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1270,9 +1270,11 @@ module BaseTest
     verify_subfields_partial_from_record(DEFAULT_HTTP_REQUEST_KEY)
   end
 
-  # Skip labels for verify_subfields_partial_from_record because labels are free
-  # range strings. Everything in the labels field should be in the resulting
-  # logEntry->labels field.
+  # We don't need a test like 'test_log_entry_labels_field_partial_from_record'
+  # becasue labels are free range strings. Everything in the labels field should
+  # be in the resulting logEntry->labels field. There is no need to check
+  # partial transformation (aka, some 'labels' fields are extracted, while
+  # others are left as it is).
 
   def test_log_entry_operation_field_partial_from_record
     verify_subfields_partial_from_record(DEFAULT_OPERATION_KEY)
@@ -2508,7 +2510,7 @@ module BaseTest
       end
       expected_params = COMPUTE_PARAMS.dup
       if log_entry_field == 'labels'
-        expected_value = expected_value.merge(COMPUTE_PARAMS[:labels])
+        expected_value = COMPUTE_PARAMS[:labels].merge(expected_value)
         expected_params[:labels] = expected_value
       end
       verify_log_entries(1, expected_params, 'jsonPayload') do |entry|

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1454,7 +1454,8 @@ module BaseTest
       nested_level_value: TRACE2)
   end
 
-  # Expected order.
+  # Verify that labels present in multiple inputs respect the expected priority
+  # order:
   # 1. Labels from the field "logging.googleapis.com/labels" in payload.
   # 2. Labels from the config "label_map".
   # 3. Labels from the config "labels".
@@ -2412,10 +2413,10 @@ module BaseTest
                      entry[destination_key].size, entry
       else
         # Leave the malformed field as it is.
-        # TODO(qingling128) In the next breaking change release, make the older
-        # fields behave the same way: if the field is not a hash as expected,
-        # log an error in the Fluentd log and remove this field from payload.
-        # This is the preferred behavior per PM decision.
+        # TODO(qingling128) On the next major after 0.7.4, make the rest of
+        # logEntry subfields behave the same way: if the field is not a hash as
+        # expected, log an error in the Fluentd log and remove this field from
+        # payload. This is the preferred behavior per PM decision.
         field = get_fields(entry['jsonPayload'])[payload_key]
         assert_equal 'a_string', get_string(field), entry
         assert_false entry.key?(destination_key), entry

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1287,11 +1287,10 @@ module BaseTest
   # Verify the subfields extraction of LogEntry fields when they are not hashes.
 
   def test_log_entry_http_request_field_when_not_hash
-    # Leave the malformed field as it is.
-    # TODO(qingling128) On the next major after 0.7.4, make the rest of
-    # logEntry subfields behave the same way: if the field is not a hash as
-    # expected, log an error in the Fluentd log and remove this field from
-    # payload. This is the preferred behavior per PM decision.
+    # TODO(qingling128) On the next major after 0.7.4, make all logEntry
+    # subfields behave the same way: if the field is not in the correct format,
+    # log an error in the Fluentd log and remove this field from payload. This
+    # is the preferred behavior per PM decision.
     verify_subfields_untouched_when_not_hash(DEFAULT_HTTP_REQUEST_KEY)
   end
 
@@ -1300,20 +1299,18 @@ module BaseTest
   end
 
   def test_log_entry_operation_field_when_not_hash
-    # Leave the malformed field as it is.
-    # TODO(qingling128) On the next major after 0.7.4, make the rest of
-    # logEntry subfields behave the same way: if the field is not a hash as
-    # expected, log an error in the Fluentd log and remove this field from
-    # payload. This is the preferred behavior per PM decision.
+    # TODO(qingling128) On the next major after 0.7.4, make all logEntry
+    # subfields behave the same way: if the field is not in the correct format,
+    # log an error in the Fluentd log and remove this field from payload. This
+    # is the preferred behavior per PM decision.
     verify_subfields_untouched_when_not_hash(DEFAULT_OPERATION_KEY)
   end
 
   def test_log_entry_source_location_field_when_not_hash
-    # Leave the malformed field as it is.
-    # TODO(qingling128) On the next major after 0.7.4, make the rest of
-    # logEntry subfields behave the same way: if the field is not a hash as
-    # expected, log an error in the Fluentd log and remove this field from
-    # payload. This is the preferred behavior per PM decision.
+    # TODO(qingling128) On the next major after 0.7.4, make all logEntry
+    # subfields behave the same way: if the field is not in the correct format,
+    # log an error in the Fluentd log and remove this field from payload. This
+    # is the preferred behavior per PM decision.
     verify_subfields_untouched_when_not_hash(DEFAULT_SOURCE_LOCATION_KEY)
   end
 
@@ -2440,6 +2437,7 @@ module BaseTest
     end
   end
 
+  # Verify that we remove the malformed field.
   def verify_subfields_removed_when_not_hash(payload_key)
     destination_key = log_entry_subfields_params[payload_key][0]
     @logs_sent = []
@@ -2458,6 +2456,7 @@ module BaseTest
     end
   end
 
+  # Verify that we leave the malformed field as it is.
   def verify_subfields_untouched_when_not_hash(payload_key)
     destination_key = log_entry_subfields_params[payload_key][0]
     @logs_sent = []

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -376,6 +376,10 @@ module Constants
     insert_id_key custom_insert_id_key
   ).freeze
 
+  CONFIG_CUSTOM_LABELS_KEY_SPECIFIED = %(
+    labels_key custom_labels_key
+  ).freeze
+
   CONFIG_CUSTOM_OPERATION_KEY_SPECIFIED = %(
     operation_key custom_operation_key
   ).freeze
@@ -390,6 +394,69 @@ module Constants
 
   CONFIG_CUSTOM_TRACE_KEY_SPECIFIED = %(
     trace_key custom_trace_key
+  ).freeze
+
+  # For 'labels' config.
+  LABELS_FROM_LABELS_CONFIG = {
+    'a_label_from_labels_config' => 'some_value',
+    'another_label_from_labels_config' => 'some_value'
+  }.freeze
+  CONFIG_LABELS = %(
+    labels #{LABELS_FROM_LABELS_CONFIG.to_json}
+  ).freeze
+
+  # For 'label_map' config.
+  LABEL_MAP_HASH = {
+    'target_field_from_payload' => 'a_label_from_label_map_config',
+    'another_target_field_from_payload' => 'another_label_from_label_map_config'
+  }.freeze
+  PAYLOAD_FOR_LABEL_MAP = {
+    'target_field_from_payload' => 'a_value',
+    'another_target_field_from_payload' => 'b_value'
+  }.freeze
+  LABELS_FROM_LABEL_MAP_CONFIG = {
+    'a_label_from_label_map_config' => 'a_value',
+    'another_label_from_label_map_config' => 'b_value'
+  }.freeze
+  CONFIG_LABEL_MAP = %(
+    label_map #{LABEL_MAP_HASH.to_json}
+  ).freeze
+
+  CONFIG_LABLES_AND_LABLE_MAP = %(
+    #{CONFIG_LABELS}
+    #{CONFIG_LABEL_MAP}
+  ).freeze
+
+  # For conflicting labels.
+  CONFLICTING_LABEL_NAME = 'conflicting_label_key'.freeze
+  CONFLICTING_LABEL_VALUE1 = 'conflicting_value_1'.freeze
+  CONFLICTING_LABEL_VALUE2 = 'conflicting_value_2'.freeze
+  CONFLICTING_LABEL_VALUE3 = 'conflicting_value_3'.freeze
+  LABELS_FROM_PAYLOAD_CONFLICTING = {
+    CONFLICTING_LABEL_NAME => CONFLICTING_LABEL_VALUE1
+  }.freeze
+  LABELS_FROM_LABEL_MAP_CONFIG_CONFLICTING = {
+    CONFLICTING_LABEL_NAME => CONFLICTING_LABEL_VALUE2
+  }.freeze
+  LABELS_FROM_LABELS_CONFIG_CONFLICTING = {
+    CONFLICTING_LABEL_NAME => CONFLICTING_LABEL_VALUE3
+  }.freeze
+
+  LABEL_MAP_HASH_CONFLICTING = {
+    'target_field_from_payload' => CONFLICTING_LABEL_NAME
+  }.freeze
+  PAYLOAD_FOR_LABEL_MAP_CONFLICTING = {
+    'target_field_from_payload' => CONFLICTING_LABEL_VALUE2
+  }.freeze
+  CONFIG_LABEL_MAP_CONFLICTING = %(
+    label_map #{LABEL_MAP_HASH_CONFLICTING.to_json}
+  ).freeze
+  CONFIG_LABELS_CONFLICTING = %(
+    labels #{LABELS_FROM_LABELS_CONFIG_CONFLICTING.to_json}
+  ).freeze
+  CONFIG_LABLES_AND_LABLE_MAP_CONFLICTING = %(
+    #{CONFIG_LABELS_CONFLICTING}
+    #{CONFIG_LABEL_MAP_CONFLICTING}
   ).freeze
 
   # Service configurations for various services.
@@ -812,6 +879,18 @@ module Constants
     'last' => false
   }.freeze
 
+  LABELS_MESSAGE = {
+    'component' => 'front-end',
+    'source' => 'user',
+    'app' => 'request-router'
+  }.freeze
+
+  LABELS_MESSAGE2 = {
+    'component' => 'front-end',
+    'source' => 'system',
+    'app' => 'request-router'
+  }.freeze
+
   CUSTOM_LABELS_MESSAGE = {
     'customKey' => 'value'
   }.freeze
@@ -1023,6 +1102,7 @@ module Constants
     'severity' => CONTAINER_SEVERITY,
     DEFAULT_HTTP_REQUEST_KEY => HTTP_REQUEST_MESSAGE,
     DEFAULT_INSERT_ID_KEY => INSERT_ID,
+    DEFAULT_LABELS_KEY => LABELS_MESSAGE,
     DEFAULT_OPERATION_KEY => OPERATION_MESSAGE,
     DEFAULT_SOURCE_LOCATION_KEY => SOURCE_LOCATION_MESSAGE,
     DEFAULT_SPAN_ID_KEY => SPAN_ID,

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -364,8 +364,10 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
 
   # Verify the number and the content of the log entries match the expectation.
   # The caller can optionally provide a block which is called for each entry.
-  def verify_log_entries(n, params, payload_type = 'textPayload', &block)
-    verify_json_log_entries(n, params, payload_type, &block)
+  def verify_log_entries(n, params, payload_type = 'textPayload',
+                         check_exact_entry_labels = true, &block)
+    verify_json_log_entries(n, params, payload_type, check_exact_entry_labels,
+                            &block)
   end
 
   # For an optional field with default values, Protobuf omits the field when it

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -413,7 +413,8 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
 
   # Verify the number and the content of the log entries match the expectation.
   # The caller can optionally provide a block which is called for each entry.
-  def verify_log_entries(n, params, payload_type = 'textPayload', &block)
+  def verify_log_entries(n, params, payload_type = 'textPayload',
+                         check_exact_entry_labels = true, &block)
     @requests_sent.each do |request|
       @logs_sent << {
         'entries' => request.entries.map { |entry| JSON.parse(entry.to_json) },
@@ -422,7 +423,8 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
         'logName' => request.log_name
       }
     end
-    verify_json_log_entries(n, params, payload_type, &block)
+    verify_json_log_entries(n, params, payload_type, check_exact_entry_labels,
+                            &block)
   end
 
   # Use the right single quotation mark as the sample non-utf8 character.


### PR DESCRIPTION
Extract `logging.googleapis.com/labels` (the field name can be customized by the configuration `labels_key`) and set those labels in logEntry->labels.

If a `logging.googleapis.com/labels` field (or a customized field whose name is specified by `labels_key`) is present in the log entry, the field is stripped from the payload and assigned to the [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry) labels field.

This is similar to how we handle the other fields for logEntry: https://cloud.google.com/logging/docs/agent/configuration#special-fields

Example:

Original log entry
```
{ 
  "message":  "this is a test message",
  "code": "user",
  "logging.googleapis.com/labels": {
    "app":  "logging-load-test",     
    "node":  "default-pool-3edf6d28-v1np",     
    "pod-template-hash":  "7029"   
  }  
 }
```
logEntry->jsonPayload
```
{ 
  "message":  "this is a test message",
  "code": "user"
}
```
logEntry->labels
```
{
    "app":  "logging-load-test",     
    "node":  "default-pool-3edf6d28-v1np",     
    "pod-template-hash":  "7029"   
}  
```

Note that there are 3 ways of passing in labels now. In case of label name collision, the label value respects the following priority order:
1. Labels from the field `logging.googleapis.com/labels` in payload.
2. Labels from the config `label_map`.
3. Labels from the config `labels`.