### PR TITLE
Bump grpc version to 1.14.2.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -25,7 +25,7 @@ eos
   gem.add_runtime_dependency 'google-api-client', '0.23.9'
   gem.add_runtime_dependency 'google-cloud-logging', '1.5.4'
   gem.add_runtime_dependency 'google-protobuf', '3.6.1'
-  gem.add_runtime_dependency 'grpc', '1.8.3'
+  gem.add_runtime_dependency 'grpc', '1.14.2'
   gem.add_runtime_dependency 'json', '2.1.0'
 
   gem.add_development_dependency 'mocha', '~> 1.1'


### PR DESCRIPTION
grpc has fixed certain bugs, and include https_proxy environment variable features we might be interested:
- [memory leak in ruby when exception is raised in 1.10.0](https://github.com/grpc/grpc/pull/14132)
- memory leak in core module's max_age_filter and http_proxy in 1.10.0.
- [grpc core module fixes memory leak on flow control in 1.10.1](https://github.com/grpc/grpc/pull/14747)
- [https_proxy environment variable can be set in grpc core in 1.14.0](https://github.com/grpc/grpc/pull/15698)

Do not bump further because this is the minimum version provided the above bug fixes and features.