### PR TITLE
Mark the plugin multi_workers_ready.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -723,6 +723,10 @@ module Fluent
       end
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     private
 
     def compute_trace(trace)


### PR DESCRIPTION
This enables launching two or more fluentd workers to utilize multiple CPU cores.