### PR TITLE
Fix each_codepoint undefined error when input is not a string.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -2040,10 +2040,11 @@ module Fluent
                                json_payload
                              end
       elsif text_payload
+        text_payload = text_payload.to_s
         entry.text_payload = if @use_grpc
-                               convert_to_utf8(text_payload.to_s)
+                               convert_to_utf8(text_payload)
                              else
-                               text_payload.to_s
+                               text_payload
                              end
       end
     end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -2003,6 +2003,8 @@ module Fluent
       ret
     end
 
+    # TODO(qingling128): Fix the inconsistent behavior of 'message', 'log' and
+    # 'msg' in the next major version 1.0.0.
     def set_payload(resource_type, record, entry, is_json)
       # Only one of {text_payload, json_payload} will be set.
       text_payload = nil

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -2039,9 +2039,9 @@ module Fluent
                              end
       elsif text_payload
         entry.text_payload = if @use_grpc
-                               convert_to_utf8(text_payload)
+                               convert_to_utf8(text_payload.to_s)
                              else
-                               text_payload
+                               text_payload.to_s
                              end
       end
     end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -976,7 +976,6 @@ module Fluent
     end
 
     def parse_json_or_nil(input)
-      # Only here to please rubocop...
       return nil unless input.is_a?(String)
 
       input.each_codepoint do |c|

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -977,7 +977,7 @@ module Fluent
 
     def parse_json_or_nil(input)
       # Only here to please rubocop...
-      return nil if input.nil?
+      return input unless input.is_a?(String)
 
       input.each_codepoint do |c|
         if c == 123

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -977,7 +977,7 @@ module Fluent
 
     def parse_json_or_nil(input)
       # Only here to please rubocop...
-      return input unless input.is_a?(String)
+      return nil unless input.is_a?(String)
 
       input.each_codepoint do |c|
         if c == 123

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -536,7 +536,7 @@ module BaseTest
     end
   end
 
-  def test_structured_payload_json_log_detect_json_not_parsed_hash
+  def test_structured_payload_json_log_detect_json_not_parsed_log_msg_hash
     hash_value = {
       'msg' => 'test log entry 0',
       'tag2' => 'test',
@@ -562,6 +562,28 @@ module BaseTest
           assert_equal null_value, fields['some_null_field'], entry
         end
       end
+    end
+  end
+
+  # TODO(qingling128): Fix the inconsistent behavior of 'message', 'log' and
+  # 'msg' in the next major version 1.0.0.
+  def test_structured_payload_json_log_detect_json_not_parsed_message_hash
+    hash_value = {
+      'msg' => 'test log entry 0',
+      'tag2' => 'test',
+      'data' => 5000,
+      'some_null_field' => nil
+    }
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver(DETECT_JSON_CONFIG)
+      d.emit('message' => hash_value)
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'textPayload') do |entry|
+      text_payload = entry['textPayload']
+      assert_equal '{"msg"=>"test log entry 0", "tag2"=>"test", "data"=>5000,' \
+                   ' "some_null_field"=>nil}', text_payload, entry
     end
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -536,6 +536,31 @@ module BaseTest
     end
   end
 
+  def test_structured_payload_json_log_detect_json_not_parsed_hash
+    setup_gce_metadata_stubs
+    hash_value = {
+      "msg" => "test log entry 0",
+      "tag2" => "test",
+      "data" => 5000,
+      "some_null_field" => nil
+    }
+    setup_logging_stubs do
+      d = create_driver(DETECT_JSON_CONFIG)
+      %w(log message msg).each do |field|
+        d.emit(field => hash_value)
+      end
+      d.run
+    end
+    verify_log_entries(3, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      fields = get_fields(entry['jsonPayload'])
+      assert_equal 4, fields.size, entry
+      assert_equal 'test log entry 0', get_string(fields['msg']), entry
+      assert_equal 'test', get_string(fields['tag2']), entry
+      assert_equal 5000, get_number(fields['data']), entry
+      assert_equal null_value, fields['some_null_field'], entry
+    end
+  end
+
   def test_structured_payload_json_log_detect_json_parsed
     setup_gce_metadata_stubs
     json_string = '{"msg": "test log entry 0", "tag2": "test", ' \


### PR DESCRIPTION
[Warnings]

2019-03-11 20:49:54 +0000 [warn]: #0 [google_cloud] got unrecoverable error in primary and no secondary error_class=NoMethodError error="undefined method `each_codepoint' for #<Hash:0x00007f1bac785ce8>\nDid you mean?  each_cons
2019-03-11 20:49:54 +0000 [warn]: #0 [google_cloud] bad chunk is moved to /var/log/fluentd/backup/worker0/google_cloud/583d7977dc71f7fcd9a7f697a08b4483.log

[Code Snippet where the warn is thrown]
```
    def parse_json_or_nil(input)
      # Only here to please rubocop...
      return nil if input.nil?

      input.each_codepoint do |c|
        if c == 123
          # left curly bracket (U+007B)
          begin
            return JSON.parse(input)
          rescue JSON::ParserError
            return nil
          end
        else
          # Break (and return nil) unless the current character is whitespace,
          # in which case we continue to look for a left curly bracket.
          # Whitespace as per the JSON spec are: tabulation (U+0009),
          # line feed (U+000A), carriage return (U+000D), and space (U+0020).
          break unless c == 9 || c == 10 || c == 13 || c == 32
        end # case
      end # do
      nil
    end
```