### PR TITLE
Fix unsupported type error due to Fluent::EventTime.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1984,6 +1984,13 @@ module Fluent
         ret.list_value = value
       when Array
         ret.list_value = list_from_ruby(value)
+      when Fluent::EventTime
+        # Fluentd 'time' can be either an Integer or Fluent::EventTime. The
+        # record payload is not supposed to include a field in the format of
+        # Fluent::EventTime. But in rare cases, we've observed such behavior.
+        # The gRPC path should be able to handle it in the same way as the REST
+        # path (convert the field to Integer instead of erroring out).
+        ret.number_value = value.to_i
       else
         @log.error "Unknown type: #{value.class}"
         raise Google::Protobuf::Error, "Unknown type: #{value.class}"

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -994,6 +994,24 @@ module BaseTest
     end
   end
 
+  def test_fluent_event_time_format
+    current_time = Time.now
+    setup_gce_metadata_stubs
+    setup_logging_stubs do
+      d = create_driver
+      d.emit(
+        'message' => log_entry(0),
+        'some_field' => Fluent::EventTime.from_time(current_time))
+      d.run
+    end
+    verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
+      fields = get_fields(entry['jsonPayload'])
+      assert_equal 2, fields.size, entry
+      assert_equal current_time.to_i,
+                   get_number(fields['some_field']), entry
+    end
+  end
+
   # Make parse_severity public so we can test it.
   class Fluent::GoogleCloudOutput # rubocop:disable Style/ClassAndModuleChildren
     public :parse_severity


### PR DESCRIPTION
This fixes the following error:

```
[Error]
I  2019-04-02 14:30:37 +0000 [error]: #10 [google_cloud] Unknown type: Fluent::EventTime
I  2019-04-02 14:30:37 +0000 [warn]: #10 [google_cloud] failed to flush the buffer. retry_time=0 next_retry_seconds=2019-04-02 14:30:42 +0000 chunk="5858c080e327c7a41a7388f7a59b1ce8" error_class=Google::Protobuf::Error error="Unknown type: Fluent::EventTime"
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:1989:in `value_from_ruby'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:2005:in `block in struct_from_ruby'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:2004:in `each'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:2004:in `struct_from_ruby'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:2042:in `set_payload'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:686:in `block (2 levels) in write'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:613:in `each'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:613:in `block in write'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:607:in `each'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.6/lib/fluent/plugin/out_google_cloud.rb:607:in `write'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.2.5/lib/fluent/compat/output.rb:131:in `write'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.2.5/lib/fluent/plugin/output.rb:1110:in `try_flush'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.2.5/lib/fluent/plugin/output.rb:1389:in `flush_thread_run'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.2.5/lib/fluent/plugin/output.rb:444:in `block (2 levels) in start'
I    2019-04-02 14:30:37 +0000 [warn]: #10 /opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.2.5/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```