### PR TITLE
Update google-protobuf gem to 3.9.0 and adjust unit tests accordingly.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -24,7 +24,7 @@ eos
   gem.add_runtime_dependency 'googleauth', '0.8.1'
   gem.add_runtime_dependency 'google-api-client', '0.28.4'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.0'
-  gem.add_runtime_dependency 'google-protobuf', '3.6.1'
+  gem.add_runtime_dependency 'google-protobuf', '3.9.0'
   gem.add_runtime_dependency 'grpc', '1.14.2'
   gem.add_runtime_dependency 'json', '2.1.0'
 

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -2248,14 +2248,13 @@ module Fluent
     def construct_error_details_map_grpc(gax_error)
       return {} unless @partial_success
       error_details_map = Hash.new { |h, k| h[k] = [] }
-
       error_details = ensure_array(gax_error.status_details)
       raise JSON::ParserError, 'The error details are empty.' if
         error_details.empty?
       raise JSON::ParserError, 'No partial error info in error details.' unless
         error_details[0].is_a?(
           Google::Logging::V2::WriteLogEntriesPartialErrors)
-      log_entry_errors = ensure_hash(error_details[0].log_entry_errors)
+      log_entry_errors = ensure_hash_grpc(error_details[0].log_entry_errors)
       log_entry_errors.each do |index, log_entry_error|
         error_key = [log_entry_error[:code], log_entry_error[:message]].freeze
         error_details_map[error_key] << index
@@ -2342,6 +2341,10 @@ module Fluent
 
     def ensure_hash(value)
       Hash.try_convert(value) || (raise JSON::ParserError, value.class.to_s)
+    end
+
+    def ensure_hash_grpc(value)
+      value.to_h || (raise JSON::ParserError, value.class.to_s)
     end
 
     # Increment the metric for the number of successful requests.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -36,6 +36,7 @@ module Google
     # Alias the has_key? method to have the same interface as a regular map.
     class Map
       alias key? has_key?
+      alias to_hash to_h
     end
   end
 end
@@ -2254,7 +2255,7 @@ module Fluent
       raise JSON::ParserError, 'No partial error info in error details.' unless
         error_details[0].is_a?(
           Google::Logging::V2::WriteLogEntriesPartialErrors)
-      log_entry_errors = ensure_hash_grpc(error_details[0].log_entry_errors)
+      log_entry_errors = ensure_hash(error_details[0].log_entry_errors)
       log_entry_errors.each do |index, log_entry_error|
         error_key = [log_entry_error[:code], log_entry_error[:message]].freeze
         error_details_map[error_key] << index
@@ -2340,15 +2341,9 @@ module Fluent
       Array.try_convert(value) || (raise JSON::ParserError, value.class.to_s)
     end
 
-    # Convert the value to a Ruby hash for the REST path.
+    # Convert the value to a Ruby hash.
     def ensure_hash(value)
       Hash.try_convert(value) || (raise JSON::ParserError, value.class.to_s)
-    end
-
-    # Convert the value to a Ruby hash for the gRPC path.
-    # This method raises JSON::ParserError for backward compatibility.
-    def ensure_hash_grpc(value)
-      value.to_h || (raise JSON::ParserError, value.class.to_s)
     end
 
     # Increment the metric for the number of successful requests.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -2346,6 +2346,7 @@ module Fluent
     end
 
     # Convert the value to a Ruby hash for the gRPC path.
+    # This method raises JSON::ParserError for backward compatibility.
     def ensure_hash_grpc(value)
       value.to_h || (raise JSON::ParserError, value.class.to_s)
     end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -2335,16 +2335,19 @@ module Fluent
       constructed_resource
     end
 
+    # Convert the value to a Ruby array.
     def ensure_array(value)
-      Array.try_convert(value) || (raise JSON::ParserError, value.class.to_s)
+      Array.try_convert(value) || (raise TypeError, value.class.to_s)
     end
 
+    # Convert the value to a Ruby hash for the REST path.
     def ensure_hash(value)
-      Hash.try_convert(value) || (raise JSON::ParserError, value.class.to_s)
+      Hash.try_convert(value) || (raise TypeError, value.class.to_s)
     end
 
+    # Convert the value to a Ruby hash for the gRPC path.
     def ensure_hash_grpc(value)
-      value.to_h || (raise JSON::ParserError, value.class.to_s)
+      value.to_h || (raise TypeError, value.class.to_s)
     end
 
     # Increment the metric for the number of successful requests.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -2337,17 +2337,17 @@ module Fluent
 
     # Convert the value to a Ruby array.
     def ensure_array(value)
-      Array.try_convert(value) || (raise TypeError, value.class.to_s)
+      Array.try_convert(value) || (raise JSON::ParserError, value.class.to_s)
     end
 
     # Convert the value to a Ruby hash for the REST path.
     def ensure_hash(value)
-      Hash.try_convert(value) || (raise TypeError, value.class.to_s)
+      Hash.try_convert(value) || (raise JSON::ParserError, value.class.to_s)
     end
 
     # Convert the value to a Ruby hash for the gRPC path.
     def ensure_hash_grpc(value)
-      value.to_h || (raise TypeError, value.class.to_s)
+      value.to_h || (raise JSON::ParserError, value.class.to_s)
     end
 
     # Increment the metric for the number of successful requests.

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -982,7 +982,7 @@ module BaseTest
           d.run
           verify_log_entries(emit_index, COMPUTE_PARAMS) do |entry, i|
             verify_default_log_entry_text(entry['textPayload'], i, entry)
-            actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+            actual_seconds = timestamp_seconds(entry['timestamp'])
             actual_nanos = entry_timestamp_nanos(entry['timestamp'])
             assert_equal_with_default actual_seconds, expected_ts.tv_sec,
                                       default_nano_value, entry
@@ -1192,7 +1192,7 @@ module BaseTest
     ) { |_, oldval, newval| oldval.merge(newval) }
     verify_log_entries(1, expected_params) do |entry, i|
       verify_default_log_entry_text(entry['textPayload'], i, entry)
-      actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+      actual_seconds = timestamp_seconds(entry['timestamp'])
       actual_nanos = entry_timestamp_nanos(entry['timestamp'])
       assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
       assert_equal K8S_NANOS, actual_nanos, entry
@@ -1217,7 +1217,7 @@ module BaseTest
       assert_equal 'test log entry 0', fields['msg'], entry
       assert_equal 'test', fields['tag2'], entry
       assert_equal 5000, fields['data'], entry
-      actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+      actual_seconds = timestamp_seconds(entry['timestamp'])
       actual_nanos = entry_timestamp_nanos(entry['timestamp'])
       assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
       assert_equal K8S_NANOS, actual_nanos, entry
@@ -1242,7 +1242,7 @@ module BaseTest
       assert_equal 'test log entry 0', fields['msg'], entry
       assert_equal 'test', fields['tag2'], entry
       assert_equal 5000, fields['data'], entry
-      actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+      actual_seconds = timestamp_seconds(entry['timestamp'])
       actual_nanos = entry_timestamp_nanos(entry['timestamp'])
       assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
       assert_equal K8S_NANOS, actual_nanos, entry
@@ -1978,7 +1978,7 @@ module BaseTest
       verify_log_entries(1, DOCKER_CONTAINER_PARAMS_NO_STREAM) do |entry, i|
         verify_default_log_entry_text(entry['textPayload'], i, entry)
         # Timestamp in 'time' field from log entry should be set properly.
-        actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+        actual_seconds = timestamp_seconds(entry['timestamp'])
         actual_nanos = entry_timestamp_nanos(entry['timestamp'])
         assert_equal DOCKER_CONTAINER_SECONDS_EPOCH, actual_seconds, entry
         assert_equal DOCKER_CONTAINER_NANOS, actual_nanos, entry
@@ -2408,7 +2408,7 @@ module BaseTest
       end
       verify_log_entries(n, expected_params) do |entry, i|
         verify_default_log_entry_text(entry['textPayload'], i, entry)
-        actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+        actual_seconds = timestamp_seconds(entry['timestamp'])
         actual_nanos = entry_timestamp_nanos(entry['timestamp'])
         assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
         assert_equal K8S_NANOS, actual_nanos, entry
@@ -2779,7 +2779,7 @@ module BaseTest
     _undefined
   end
 
-  def entry_timestamp_seconds(_timestamp)
+  def timestamp_seconds(_timestamp)
     _undefined
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -361,7 +361,7 @@ module BaseTest
       verify_default_log_entry_text(fields['msg'], i, entry)
       assert_equal 'test', fields['tag2'], entry
       assert_equal 5000, fields['data'], entry
-      assert_equal nil, fields['some_null_field'], entry
+      assert_nil fields['some_null_field'], entry
     end
   end
 
@@ -623,7 +623,7 @@ module BaseTest
             assert_equal 'test log entry 0', fields['msg'], entry
             assert_equal 'test', fields['tag2'], entry
             assert_equal 5000, fields['data'], entry
-            assert_equal nil, fields['some_null_field'], entry
+            assert_nil fields['some_null_field'], entry
           end
         end
       end
@@ -648,7 +648,7 @@ module BaseTest
       assert_equal 'test log entry 0', fields['msg'], entry
       assert_equal 'test', fields['tag2'], entry
       assert_equal 5000, fields['data'], entry
-      assert_equal nil, fields['some_null_field'], entry
+      assert_nil fields['some_null_field'], entry
     end
   end
 
@@ -702,7 +702,7 @@ module BaseTest
         assert_equal 'test log entry 0', fields['msg'], entry
         assert_equal 'test', fields['tag2'], entry
         assert_equal 5000, fields['data'], entry
-        assert_equal nil, fields['some_null_field'], entry
+        assert_nil fields['some_null_field'], entry
       end
   end
 
@@ -728,7 +728,7 @@ module BaseTest
       assert_equal 'test log entry 0', fields['msg'], entry
       assert_equal 'test', fields['tag2'], entry
       assert_equal 5000, fields['data'], entry
-      assert_equal nil, fields['some_null_field'], entry
+      assert_nil fields['some_null_field'], entry
     end
   end
 
@@ -2753,10 +2753,6 @@ module BaseTest
 
   # Defined in specific gRPC or REST files.
   def expected_operation_message2
-    _undefined
-  end
-
-  def enable_grpc
     _undefined
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -356,12 +356,12 @@ module BaseTest
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry, i|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_equal 4, fields.size, entry
-      verify_default_log_entry_text(get_string(fields['msg']), i, entry)
-      assert_equal 'test', get_string(fields['tag2']), entry
-      assert_equal 5000, get_number(fields['data']), entry
-      assert_equal null_value, fields['some_null_field'], entry
+      verify_default_log_entry_text(fields['msg'], i, entry)
+      assert_equal 'test', fields['tag2'], entry
+      assert_equal 5000, fields['data'], entry
+      assert_equal nil, fields['some_null_field'], entry
     end
   end
 
@@ -474,22 +474,18 @@ module BaseTest
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_equal 7, fields.size, entry
-      assert_equal message, get_string(get_fields(get_struct(fields \
-                   ['int_key']))['1']), entry
-      assert_equal message, get_string(get_fields(get_struct(fields \
-                   ['int_array_key']))['[1, 2, 3, 4]']), entry
-      assert_equal message, get_string(get_fields(get_struct(fields \
-                   ['string_array_key']))['["a", "b", "c"]']), entry
-      assert_equal message, get_string(get_fields(get_struct(fields \
-                   ['hash_key']))['{"some_key"=>"some_value"}']), entry
-      assert_equal message, get_string(get_fields(get_struct(fields \
-                   ['mixed_key']))['{"some_key"=>["a", "b", "c"]}']), entry
-      assert_equal message, get_string(get_fields(get_struct(fields \
-                   ['symbol_key']))['some_symbol']), entry
-      assert_equal message, get_string(get_fields(get_struct(fields \
-                   ['nil_key']))['']), entry
+      assert_equal message, fields['int_key']['1'],
+                   entry
+      assert_equal message, fields['int_array_key']['[1, 2, 3, 4]'], entry
+      assert_equal message, fields['string_array_key']['["a", "b", "c"]'], entry
+      assert_equal message, fields['hash_key']['{"some_key"=>"some_value"}'],
+                   entry
+      assert_equal message,
+                   fields['mixed_key']['{"some_key"=>["a", "b", "c"]}'], entry
+      assert_equal message, fields['symbol_key']['some_symbol'], entry
+      assert_equal message, fields['nil_key'][''], entry
     end
   end
 
@@ -523,7 +519,7 @@ module BaseTest
       d.run
     end
     verify_log_entries(6, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert !fields.key?('tag2'), 'Did not expect tag2'
       assert !fields.key?('data'), 'Did not expect data'
       assert !fields.key?('some_null_field'), 'Did not expect some_null_field'
@@ -556,7 +552,7 @@ module BaseTest
       d.run
     end
     verify_log_entries(2, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert !fields.key?('tag2'), 'Did not expect tag2'
       assert !fields.key?('data'), 'Did not expect data'
       assert !fields.key?('some_null_field'), 'Did not expect some_null_field'
@@ -620,15 +616,14 @@ module BaseTest
           end
         else
           verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-            json_payload = get_fields(entry['jsonPayload'])
+            json_payload = entry['jsonPayload']
             assert_equal 1, json_payload.size, entry
-            fields = get_fields(
-              get_struct(json_payload[test_params[:field_name]]))
+            fields = json_payload[test_params[:field_name]]
             assert_equal 4, fields.size, entry
-            assert_equal 'test log entry 0', get_string(fields['msg']), entry
-            assert_equal 'test', get_string(fields['tag2']), entry
-            assert_equal 5000, get_number(fields['data']), entry
-            assert_equal null_value, fields['some_null_field'], entry
+            assert_equal 'test log entry 0', fields['msg'], entry
+            assert_equal 'test', fields['tag2'], entry
+            assert_equal 5000, fields['data'], entry
+            assert_equal nil, fields['some_null_field'], entry
           end
         end
       end
@@ -648,12 +643,12 @@ module BaseTest
       d.run
     end
     verify_log_entries(6, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_equal 4, fields.size, entry
-      assert_equal 'test log entry 0', get_string(fields['msg']), entry
-      assert_equal 'test', get_string(fields['tag2']), entry
-      assert_equal 5000, get_number(fields['data']), entry
-      assert_equal null_value, fields['some_null_field'], entry
+      assert_equal 'test log entry 0', fields['msg'], entry
+      assert_equal 'test', fields['tag2'], entry
+      assert_equal 5000, fields['data'], entry
+      assert_equal nil, fields['some_null_field'], entry
     end
   end
 
@@ -702,12 +697,12 @@ module BaseTest
     end
     verify_log_entries(2, CONTAINER_FROM_METADATA_PARAMS, 'jsonPayload') \
       do |entry|
-        fields = get_fields(entry['jsonPayload'])
+        fields = entry['jsonPayload']
         assert_equal 4, fields.size, entry
-        assert_equal 'test log entry 0', get_string(fields['msg']), entry
-        assert_equal 'test', get_string(fields['tag2']), entry
-        assert_equal 5000, get_number(fields['data']), entry
-        assert_equal null_value, fields['some_null_field'], entry
+        assert_equal 'test log entry 0', fields['msg'], entry
+        assert_equal 'test', fields['tag2'], entry
+        assert_equal 5000, fields['data'], entry
+        assert_equal nil, fields['some_null_field'], entry
       end
   end
 
@@ -728,12 +723,12 @@ module BaseTest
     expected_params = COMPUTE_PARAMS.merge(
       labels: COMPUTE_PARAMS[:labels].merge(LABELS_MESSAGE))
     verify_log_entries(3, expected_params, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_equal 4, fields.size, entry
-      assert_equal 'test log entry 0', get_string(fields['msg']), entry
-      assert_equal 'test', get_string(fields['tag2']), entry
-      assert_equal 5000, get_number(fields['data']), entry
-      assert_equal null_value, fields['some_null_field'], entry
+      assert_equal 'test log entry 0', fields['msg'], entry
+      assert_equal 'test', fields['tag2'], entry
+      assert_equal 5000, fields['data'], entry
+      assert_equal nil, fields['some_null_field'], entry
     end
   end
 
@@ -987,18 +982,18 @@ module BaseTest
           d.run
           verify_log_entries(emit_index, COMPUTE_PARAMS) do |entry, i|
             verify_default_log_entry_text(entry['textPayload'], i, entry)
-            assert_equal_with_default entry['timestamp']['seconds'],
-                                      expected_ts.tv_sec, 0, entry
-            assert_equal_with_default \
-              entry['timestamp']['nanos'],
-              expected_ts.tv_nsec, 0, entry do
+            actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+            actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+            assert_equal_with_default actual_seconds, expected_ts.tv_sec,
+                                      default_nano_value, entry
+            assert_equal_with_default actual_nanos, expected_ts.tv_nsec,
+                                      default_nano_value, entry do
               # Fluentd v0.14 onwards supports nanosecond timestamp values.
               # Added in 600 ns delta to avoid flaky tests introduced
               # due to rounding error in double-precision floating-point numbers
               # (to account for the missing 9 bits of precision ~ 512 ns).
               # See http://wikipedia.org/wiki/Double-precision_floating-point_format.
-              assert_in_delta expected_ts.tv_nsec,
-                              entry['timestamp']['nanos'], 600, entry
+              assert_in_delta expected_ts.tv_nsec, actual_nanos, 600, entry
             end
           end
         end
@@ -1015,9 +1010,9 @@ module BaseTest
       d.run
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_equal 2, fields.size, entry
-      assert_equal 'not-a-hash', get_string(fields['timestamp']), entry
+      assert_equal 'not-a-hash', fields['timestamp'], entry
     end
   end
 
@@ -1108,10 +1103,10 @@ module BaseTest
     params[:labels]['foo.googleapis.com/bar'] = 'value2'
     params[:labels]['label3'] = 'value3'
     verify_log_entries(1, params, 'jsonPayload') do |entry, i|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_equal 2, fields.size, entry
-      verify_default_log_entry_text(get_string(fields['message']), i, entry)
-      assert_equal 'value4', get_string(fields['not_a_label']), entry
+      verify_default_log_entry_text(fields['message'], i, entry)
+      assert_equal 'value4', fields['not_a_label'], entry
     end
   end
 
@@ -1197,8 +1192,10 @@ module BaseTest
     ) { |_, oldval, newval| oldval.merge(newval) }
     verify_log_entries(1, expected_params) do |entry, i|
       verify_default_log_entry_text(entry['textPayload'], i, entry)
-      assert_equal K8S_SECONDS_EPOCH, entry['timestamp']['seconds'], entry
-      assert_equal K8S_NANOS, entry['timestamp']['nanos'], entry
+      actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+      actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+      assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
+      assert_equal K8S_NANOS, actual_nanos, entry
       assert_equal 'ERROR', entry['severity'], entry
     end
   end
@@ -1215,13 +1212,15 @@ module BaseTest
     end
     verify_log_entries(1, CONTAINER_FROM_METADATA_PARAMS,
                        'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_equal 3, fields.size, entry
-      assert_equal 'test log entry 0', get_string(fields['msg']), entry
-      assert_equal 'test', get_string(fields['tag2']), entry
-      assert_equal 5000, get_number(fields['data']), entry
-      assert_equal K8S_SECONDS_EPOCH, entry['timestamp']['seconds'], entry
-      assert_equal K8S_NANOS, entry['timestamp']['nanos'], entry
+      assert_equal 'test log entry 0', fields['msg'], entry
+      assert_equal 'test', fields['tag2'], entry
+      assert_equal 5000, fields['data'], entry
+      actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+      actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+      assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
+      assert_equal K8S_NANOS, actual_nanos, entry
       assert_equal 'WARNING', entry['severity'], entry
     end
   end
@@ -1238,13 +1237,15 @@ module BaseTest
     end
     verify_log_entries(1, CONTAINER_FROM_TAG_PARAMS,
                        'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_equal 3, fields.size, entry
-      assert_equal 'test log entry 0', get_string(fields['msg']), entry
-      assert_equal 'test', get_string(fields['tag2']), entry
-      assert_equal 5000, get_number(fields['data']), entry
-      assert_equal K8S_SECONDS_EPOCH, entry['timestamp']['seconds'], entry
-      assert_equal K8S_NANOS, entry['timestamp']['nanos'], entry
+      assert_equal 'test log entry 0', fields['msg'], entry
+      assert_equal 'test', fields['tag2'], entry
+      assert_equal 5000, fields['data'], entry
+      actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+      actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+      assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
+      assert_equal K8S_NANOS, actual_nanos, entry
       assert_equal 'WARNING', entry['severity'], entry
     end
   end
@@ -1382,7 +1383,7 @@ module BaseTest
       verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
         assert_equal http_request_message_with_absent_referer,
                      entry['httpRequest'], entry
-        assert_nil get_fields(entry['jsonPayload'])['httpRequest'], entry
+        assert_nil entry['jsonPayload']['httpRequest'], entry
       end
     end
   end
@@ -1399,7 +1400,7 @@ module BaseTest
       verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
         assert_equal http_request_message.merge('latency' => expected),
                      entry['httpRequest'], entry
-        assert_nil get_fields(entry['jsonPayload'])['httpRequest'], entry
+        assert_nil entry['jsonPayload']['httpRequest'], entry
       end
     end
   end
@@ -1419,7 +1420,7 @@ module BaseTest
       end
       verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
         assert_equal http_request_message, entry['httpRequest'], entry
-        assert_nil get_fields(entry['jsonPayload'])['httpRequest'], entry
+        assert_nil entry['jsonPayload']['httpRequest'], entry
       end
     end
   end
@@ -1678,11 +1679,11 @@ module BaseTest
           d.run
         end
         verify_log_entries(n, DOCKER_CONTAINER_PARAMS, 'jsonPayload') do |entry|
-          fields = get_fields(entry['jsonPayload'])
+          fields = entry['jsonPayload']
           assert_equal 3, fields.size, entry
-          assert_equal "test log entry #{n}", get_string(fields['msg']), entry
-          assert_equal 'test', get_string(fields['tag2']), entry
-          assert_equal 5000, get_number(fields['data']), entry
+          assert_equal "test log entry #{n}", fields['msg'], entry
+          assert_equal 'test', fields['tag2'], entry
+          assert_equal 5000, fields['data'], entry
         end
         assert_requested_metadata_agent_stub("container.#{DOCKER_CONTAINER_ID}")
       end
@@ -1797,10 +1798,10 @@ module BaseTest
         end
         verify_log_entries(1, test_params[:expected_params],
                            'jsonPayload') do |entry|
-          fields = get_fields(entry['jsonPayload'])
+          fields = entry['jsonPayload']
           assert_equal 2, fields.size, entry
-          assert_equal 'test log entry 0', get_string(fields['log']), entry
-          assert_equal K8S_STREAM, get_string(fields['stream']), entry
+          assert_equal 'test log entry 0', fields['log'], entry
+          assert_equal K8S_STREAM, fields['stream'], entry
         end
       end
     end
@@ -1894,10 +1895,10 @@ module BaseTest
         end
         verify_log_entries(1, test_params[:expected_params],
                            'jsonPayload') do |entry|
-          fields = get_fields(entry['jsonPayload'])
+          fields = entry['jsonPayload']
           assert_equal 2, fields.size, entry
-          assert_equal 'test log entry 0', get_string(fields['log']), entry
-          assert_equal K8S_STREAM, get_string(fields['stream']), entry
+          assert_equal 'test log entry 0', fields['log'], entry
+          assert_equal K8S_STREAM, fields['stream'], entry
         end
       end
     end
@@ -1954,10 +1955,10 @@ module BaseTest
         end
         verify_log_entries(1, test_params[:expected_params],
                            'jsonPayload') do |entry|
-          fields = get_fields(entry['jsonPayload'])
+          fields = entry['jsonPayload']
           assert_equal 2, fields.size, entry
-          assert_equal 'test log entry 0', get_string(fields['log']), entry
-          assert_equal K8S_STREAM, get_string(fields['stream']), entry
+          assert_equal 'test log entry 0', fields['log'], entry
+          assert_equal K8S_STREAM, fields['stream'], entry
         end
       end
     end
@@ -1977,10 +1978,10 @@ module BaseTest
       verify_log_entries(1, DOCKER_CONTAINER_PARAMS_NO_STREAM) do |entry, i|
         verify_default_log_entry_text(entry['textPayload'], i, entry)
         # Timestamp in 'time' field from log entry should be set properly.
-        assert_equal DOCKER_CONTAINER_SECONDS_EPOCH,
-                     entry['timestamp']['seconds'], entry
-        assert_equal DOCKER_CONTAINER_NANOS,
-                     entry['timestamp']['nanos'], entry
+        actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+        actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+        assert_equal DOCKER_CONTAINER_SECONDS_EPOCH, actual_seconds, entry
+        assert_equal DOCKER_CONTAINER_NANOS, actual_nanos, entry
       end
       assert_requested_metadata_agent_stub(
         "#{DOCKER_CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{DOCKER_CONTAINER_NAME}")
@@ -2407,8 +2408,10 @@ module BaseTest
       end
       verify_log_entries(n, expected_params) do |entry, i|
         verify_default_log_entry_text(entry['textPayload'], i, entry)
-        assert_equal K8S_SECONDS_EPOCH, entry['timestamp']['seconds'], entry
-        assert_equal K8S_NANOS, entry['timestamp']['nanos'], entry
+        actual_seconds = entry_timestamp_seconds(entry['timestamp'])
+        actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+        assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
+        assert_equal K8S_NANOS, actual_nanos, entry
         assert_equal CONTAINER_SEVERITY, entry['severity'], entry
       end
     end
@@ -2442,7 +2445,7 @@ module BaseTest
     verify_log_entries(1, COMPUTE_PARAMS, destination_key,
                        check_exact_entry_labels) do |entry|
       assert_equal payload_value, entry[destination_key], entry
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_nil fields[payload_key], entry
     end
   end
@@ -2458,9 +2461,9 @@ module BaseTest
     end
     verify_log_entries(1, COMPUTE_PARAMS, destination_key) do |entry|
       assert_equal payload_value, entry[destination_key], entry
-      fields = get_fields(entry['jsonPayload'])
-      request = get_fields(get_struct(fields[payload_key]))
-      assert_equal 'value', get_string(request['otherKey']), entry
+      fields = entry['jsonPayload']
+      request = fields[payload_key]
+      assert_equal 'value', request['otherKey'], entry
     end
   end
 
@@ -2475,7 +2478,7 @@ module BaseTest
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
       # The malformed field has been removed from the payload.
-      assert_true get_fields(entry['jsonPayload']).empty?, entry
+      assert_true entry['jsonPayload'].empty?, entry
       # No additional labels.
       assert_equal COMPUTE_PARAMS[:labels].size,
                    entry[destination_key].size, entry
@@ -2493,8 +2496,8 @@ module BaseTest
     end
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
       # Verify that we leave the malformed field as it is.
-      field = get_fields(entry['jsonPayload'])[payload_key]
-      assert_equal 'a_string', get_string(field), entry
+      field = entry['jsonPayload'][payload_key]
+      assert_equal 'a_string', field, entry
       assert_false entry.key?(destination_key), entry
     end
   end
@@ -2510,7 +2513,7 @@ module BaseTest
     end
 
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
-      fields = get_fields(entry['jsonPayload'])
+      fields = entry['jsonPayload']
       assert_false fields.key?(payload_key), entry
       if payload_key == DEFAULT_LABELS_KEY
         # No additional labels.
@@ -2602,10 +2605,10 @@ module BaseTest
           entry[log_entry_field], expected_value, default_value,
           "Index #{index} failed. #{expected_value} is expected for " \
           "#{log_entry_field} field."
-        payload_fields = get_fields(entry['jsonPayload'])
+        payload_fields = entry['jsonPayload']
         assert_equal structured_log_entry.size, payload_fields.size
         payload_fields.each do |key, value|
-          assert_equal structured_log_entry[key], get_string(value)
+          assert_equal structured_log_entry[key], value
         end
       end
     end
@@ -2658,10 +2661,12 @@ module BaseTest
       end
       verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload', false) do |entry|
         assert_equal input[:expected_field_value], entry[log_entry_field], input
-        payload_fields = get_fields(entry['jsonPayload'])
+        payload_fields = entry['jsonPayload']
         assert_equal input[:expected_payload].size, payload_fields.size, input
         payload_fields.each do |key, value|
-          assert_hash_equal_json(input[:expected_payload][key], value)
+          expected = input[:expected_payload][key]
+          assert_equal expected, value,
+                       "expected: #{expected}\nactual: #{value}"
         end
       end
     end
@@ -2681,22 +2686,23 @@ module BaseTest
 
   # The conversions from user input to output.
   def latency_conversion
+    _undefined
     {
-      '32 s' => { 'seconds' => 32 },
-      '32s' => { 'seconds' => 32 },
-      '0.32s' => { 'nanos' => 320_000_000 },
-      ' 123 s ' => { 'seconds' => 123 },
-      '1.3442 s' => { 'seconds' => 1, 'nanos' => 344_200_000 },
+      '32 s' => '32s',
+      '32s' => '32s',
+      '0.32s' => '0.320000000s',
+      ' 123 s ' => '123s',
+      '1.3442 s' => '1.344200000s',
 
       # Test whitespace.
       # \t: tab. \r: carriage return. \n: line break.
       # \v: vertical whitespace. \f: form feed.
-      "\t123.5\ts\t" => { 'seconds' => 123, 'nanos' => 500_000_000 },
-      "\r123.5\rs\r" => { 'seconds' => 123, 'nanos' => 500_000_000 },
-      "\n123.5\ns\n" => { 'seconds' => 123, 'nanos' => 500_000_000 },
-      "\v123.5\vs\v" => { 'seconds' => 123, 'nanos' => 500_000_000 },
-      "\f123.5\fs\f" => { 'seconds' => 123, 'nanos' => 500_000_000 },
-      "\r123.5\ts\f" => { 'seconds' => 123, 'nanos' => 500_000_000 }
+      "\t123.5\ts\t" => '123.500000000s',
+      "\r123.5\rs\r" => '123.500000000s',
+      "\n123.5\ns\n" => '123.500000000s',
+      "\v123.5\vs\v" => '123.500000000s',
+      "\f123.5\fs\f" => '123.500000000s',
+      "\r123.5\ts\f" => '123.500000000s'
     }
   end
 
@@ -2741,31 +2747,6 @@ module BaseTest
     assert_equal(expected_value, metric_value)
   end
 
-  # Get the fields of the payload.
-  def get_fields(_payload)
-    _undefined
-  end
-
-  # Get the value of a struct field.
-  def get_struct(_field)
-    _undefined
-  end
-
-  # Get the value of a string field.
-  def get_string(_field)
-    _undefined
-  end
-
-  # Get the value of a number field.
-  def get_number(_field)
-    _undefined
-  end
-
-  # The null value.
-  def null_value(_field)
-    _undefined
-  end
-
   # Defined in specific gRPC or REST files.
   def http_request_message
     _undefined
@@ -2786,12 +2767,23 @@ module BaseTest
     _undefined
   end
 
-  # Defined in specific gRPC or REST files.
-  def assert_hash_equal_json(_expected, _actual)
+  def _undefined
+    raise "Method #{__callee__} is unimplemented and needs to be overridden."
+  end
+
+  def enable_grpc
     _undefined
   end
 
-  def _undefined
-    raise "Method #{__callee__} is unimplemented and needs to be overridden."
+  def default_nano_value
+    _undefined
+  end
+
+  def entry_timestamp_seconds(_timestamp)
+    _undefined
+  end
+
+  def entry_timestamp_nanos(_timestamp)
+    _undefined
   end
 end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -988,7 +988,8 @@ module BaseTest
             # due to rounding error in double-precision floating-point numbers
             # (to account for the missing 9 bits of precision ~ 512 ns).
             # See http://wikipedia.org/wiki/Double-precision_floating-point_format.
-            assert_in_delta expected_ts.tv_nsec, actual_timestamp['nanos'], 600, entry
+            assert_in_delta expected_ts.tv_nsec, actual_timestamp['nanos'],
+                            600, entry
           end
         end
       end
@@ -1970,7 +1971,8 @@ module BaseTest
         verify_default_log_entry_text(entry['textPayload'], i, entry)
         # Timestamp in 'time' field from log entry should be set properly.
         actual_timestamp = timestamp_parse(entry['timestamp'])
-        assert_equal DOCKER_CONTAINER_SECONDS_EPOCH, actual_timestamp['seconds'], entry
+        assert_equal DOCKER_CONTAINER_SECONDS_EPOCH,
+                     actual_timestamp['seconds'], entry
         assert_equal DOCKER_CONTAINER_NANOS, actual_timestamp['nanos'], entry
       end
       assert_requested_metadata_agent_stub(
@@ -2722,6 +2724,9 @@ module BaseTest
     _undefined
   end
 
+  # Parse timestamp and convert it to a hash with the "seconds" and "nanos" keys
+  # if necessary.
+  # Defined in specific gRPC or REST files.
   def timestamp_parse(_timestamp)
     _undefined
   end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -981,15 +981,14 @@ module BaseTest
           d.run
           verify_log_entries(emit_index, COMPUTE_PARAMS) do |entry, i|
             verify_default_log_entry_text(entry['textPayload'], i, entry)
-            actual_seconds = timestamp_seconds(entry['timestamp'])
-            actual_nanos = timestamp_nanos(entry['timestamp'])
-            assert_equal actual_seconds, expected_ts.tv_sec, entry
+            actual_timestamp = timestamp_parse(entry['timestamp'])
+            assert_equal actual_timestamp['seconds'], expected_ts.tv_sec, entry
             # Fluentd v0.14 onwards supports nanosecond timestamp values.
             # Added in 600 ns delta to avoid flaky tests introduced
             # due to rounding error in double-precision floating-point numbers
             # (to account for the missing 9 bits of precision ~ 512 ns).
             # See http://wikipedia.org/wiki/Double-precision_floating-point_format.
-            assert_in_delta expected_ts.tv_nsec, actual_nanos, 600, entry
+            assert_in_delta expected_ts.tv_nsec, actual_timestamp['nanos'], 600, entry
           end
         end
       end
@@ -1187,10 +1186,9 @@ module BaseTest
     ) { |_, oldval, newval| oldval.merge(newval) }
     verify_log_entries(1, expected_params) do |entry, i|
       verify_default_log_entry_text(entry['textPayload'], i, entry)
-      actual_seconds = timestamp_seconds(entry['timestamp'])
-      actual_nanos = timestamp_nanos(entry['timestamp'])
-      assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
-      assert_equal K8S_NANOS, actual_nanos, entry
+      actual_timestamp = timestamp_parse(entry['timestamp'])
+      assert_equal K8S_SECONDS_EPOCH, actual_timestamp['seconds'], entry
+      assert_equal K8S_NANOS, actual_timestamp['nanos'], entry
       assert_equal 'ERROR', entry['severity'], entry
     end
   end
@@ -1212,10 +1210,9 @@ module BaseTest
       assert_equal 'test log entry 0', fields['msg'], entry
       assert_equal 'test', fields['tag2'], entry
       assert_equal 5000, fields['data'], entry
-      actual_seconds = timestamp_seconds(entry['timestamp'])
-      actual_nanos = timestamp_nanos(entry['timestamp'])
-      assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
-      assert_equal K8S_NANOS, actual_nanos, entry
+      actual_timestamp = timestamp_parse(entry['timestamp'])
+      assert_equal K8S_SECONDS_EPOCH, actual_timestamp['seconds'], entry
+      assert_equal K8S_NANOS, actual_timestamp['nanos'], entry
       assert_equal 'WARNING', entry['severity'], entry
     end
   end
@@ -1237,10 +1234,9 @@ module BaseTest
       assert_equal 'test log entry 0', fields['msg'], entry
       assert_equal 'test', fields['tag2'], entry
       assert_equal 5000, fields['data'], entry
-      actual_seconds = timestamp_seconds(entry['timestamp'])
-      actual_nanos = timestamp_nanos(entry['timestamp'])
-      assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
-      assert_equal K8S_NANOS, actual_nanos, entry
+      actual_timestamp = timestamp_parse(entry['timestamp'])
+      assert_equal K8S_SECONDS_EPOCH, actual_timestamp['seconds'], entry
+      assert_equal K8S_NANOS, actual_timestamp['nanos'], entry
       assert_equal 'WARNING', entry['severity'], entry
     end
   end
@@ -1973,10 +1969,9 @@ module BaseTest
       verify_log_entries(1, DOCKER_CONTAINER_PARAMS_NO_STREAM) do |entry, i|
         verify_default_log_entry_text(entry['textPayload'], i, entry)
         # Timestamp in 'time' field from log entry should be set properly.
-        actual_seconds = timestamp_seconds(entry['timestamp'])
-        actual_nanos = timestamp_nanos(entry['timestamp'])
-        assert_equal DOCKER_CONTAINER_SECONDS_EPOCH, actual_seconds, entry
-        assert_equal DOCKER_CONTAINER_NANOS, actual_nanos, entry
+        actual_timestamp = timestamp_parse(entry['timestamp'])
+        assert_equal DOCKER_CONTAINER_SECONDS_EPOCH, actual_timestamp['seconds'], entry
+        assert_equal DOCKER_CONTAINER_NANOS, actual_timestamp['nanos'], entry
       end
       assert_requested_metadata_agent_stub(
         "#{DOCKER_CONTAINER_LOCAL_RESOURCE_ID_PREFIX}.#{DOCKER_CONTAINER_NAME}")
@@ -2403,10 +2398,9 @@ module BaseTest
       end
       verify_log_entries(n, expected_params) do |entry, i|
         verify_default_log_entry_text(entry['textPayload'], i, entry)
-        actual_seconds = timestamp_seconds(entry['timestamp'])
-        actual_nanos = timestamp_nanos(entry['timestamp'])
-        assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
-        assert_equal K8S_NANOS, actual_nanos, entry
+        actual_timestamp = timestamp_parse(entry['timestamp'])
+        assert_equal K8S_SECONDS_EPOCH, actual_timestamp['seconds'], entry
+        assert_equal K8S_NANOS, actual_timestamp['nanos'], entry
         assert_equal CONTAINER_SEVERITY, entry['severity'], entry
       end
     end
@@ -2728,15 +2722,7 @@ module BaseTest
     _undefined
   end
 
-  def default_nano_value
-    _undefined
-  end
-
-  def timestamp_seconds(_timestamp)
-    _undefined
-  end
-
-  def timestamp_nanos(_timestamp)
+  def timestamp_parse(_timestamp)
     _undefined
   end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -1394,11 +1394,11 @@ module BaseTest
       setup_logging_stubs do
         d = create_driver
         @logs_sent = []
-        d.emit('httpRequest' => http_request_message.merge('latency' => input))
+        d.emit('httpRequest' => HTTP_REQUEST_MESSAGE.merge('latency' => input))
         d.run
       end
       verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
-        assert_equal http_request_message.merge('latency' => expected),
+        assert_equal HTTP_REQUEST_MESSAGE.merge('latency' => expected),
                      entry['httpRequest'], entry
         assert_nil entry['jsonPayload']['httpRequest'], entry
       end
@@ -1415,11 +1415,11 @@ module BaseTest
       setup_logging_stubs do
         d = create_driver
         @logs_sent = []
-        d.emit('httpRequest' => http_request_message.merge('latency' => input))
+        d.emit('httpRequest' => HTTP_REQUEST_MESSAGE.merge('latency' => input))
         d.run
       end
       verify_log_entries(1, COMPUTE_PARAMS, 'httpRequest') do |entry|
-        assert_equal http_request_message, entry['httpRequest'], entry
+        assert_equal HTTP_REQUEST_MESSAGE, entry['httpRequest'], entry
         assert_nil entry['jsonPayload']['httpRequest'], entry
       end
     end
@@ -1459,7 +1459,7 @@ module BaseTest
                      custom_key: 'custom_source_location_key',
                      custom_key_config: \
                        CONFIG_CUSTOM_SOURCE_LOCATION_KEY_SPECIFIED,
-                     sample_value: source_location_message)
+                     sample_value: SOURCE_LOCATION_MESSAGE)
   end
 
   def test_log_entry_span_id_field
@@ -1517,8 +1517,8 @@ module BaseTest
   def test_cascading_json_detection_with_log_entry_source_location_field
     verify_cascading_json_detection_with_log_entry_fields(
       'sourceLocation', DEFAULT_SOURCE_LOCATION_KEY,
-      root_level_value: source_location_message,
-      nested_level_value: source_location_message2)
+      root_level_value: SOURCE_LOCATION_MESSAGE,
+      nested_level_value: SOURCE_LOCATION_MESSAGE2)
   end
 
   def test_cascading_json_detection_with_log_entry_span_id_field
@@ -2423,13 +2423,13 @@ module BaseTest
       # LogEntry info from. The values are lists of two elements: the name of
       # the subfield in LogEntry object and the expected value of that field.
       DEFAULT_HTTP_REQUEST_KEY => [
-        'httpRequest', http_request_message],
+        'httpRequest', HTTP_REQUEST_MESSAGE],
       DEFAULT_LABELS_KEY => [
         'labels', COMPUTE_PARAMS[:labels].merge(LABELS_MESSAGE)],
       DEFAULT_OPERATION_KEY => [
         'operation', OPERATION_MESSAGE],
       DEFAULT_SOURCE_LOCATION_KEY => [
-        'sourceLocation', source_location_message]
+        'sourceLocation', SOURCE_LOCATION_MESSAGE]
     }
   end
 
@@ -2674,12 +2674,12 @@ module BaseTest
 
   # Replace the 'referer' field with nil.
   def http_request_message_with_nil_referer
-    http_request_message.merge('referer' => nil)
+    HTTP_REQUEST_MESSAGE.merge('referer' => nil)
   end
 
   # Unset the 'referer' field.
   def http_request_message_with_absent_referer
-    http_request_message.reject do |k, _|
+    HTTP_REQUEST_MESSAGE.reject do |k, _|
       k == 'referer'
     end
   end
@@ -2747,28 +2747,13 @@ module BaseTest
     assert_equal(expected_value, metric_value)
   end
 
-  # Defined in specific gRPC or REST files.
-  def http_request_message
-    _undefined
-  end
-
-  # Defined in specific gRPC or REST files.
-  def source_location_message
-    _undefined
-  end
-
-  # Defined in specific gRPC or REST files.
-  def source_location_message2
-    _undefined
+  def _undefined
+    raise "Method #{__callee__} is unimplemented and needs to be overridden."
   end
 
   # Defined in specific gRPC or REST files.
   def expected_operation_message2
     _undefined
-  end
-
-  def _undefined
-    raise "Method #{__callee__} is unimplemented and needs to be overridden."
   end
 
   def enable_grpc

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -983,7 +983,7 @@ module BaseTest
           verify_log_entries(emit_index, COMPUTE_PARAMS) do |entry, i|
             verify_default_log_entry_text(entry['textPayload'], i, entry)
             actual_seconds = timestamp_seconds(entry['timestamp'])
-            actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+            actual_nanos = timestamp_nanos(entry['timestamp'])
             assert_equal_with_default actual_seconds, expected_ts.tv_sec,
                                       default_nano_value, entry
             assert_equal_with_default actual_nanos, expected_ts.tv_nsec,
@@ -1193,7 +1193,7 @@ module BaseTest
     verify_log_entries(1, expected_params) do |entry, i|
       verify_default_log_entry_text(entry['textPayload'], i, entry)
       actual_seconds = timestamp_seconds(entry['timestamp'])
-      actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+      actual_nanos = timestamp_nanos(entry['timestamp'])
       assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
       assert_equal K8S_NANOS, actual_nanos, entry
       assert_equal 'ERROR', entry['severity'], entry
@@ -1218,7 +1218,7 @@ module BaseTest
       assert_equal 'test', fields['tag2'], entry
       assert_equal 5000, fields['data'], entry
       actual_seconds = timestamp_seconds(entry['timestamp'])
-      actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+      actual_nanos = timestamp_nanos(entry['timestamp'])
       assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
       assert_equal K8S_NANOS, actual_nanos, entry
       assert_equal 'WARNING', entry['severity'], entry
@@ -1243,7 +1243,7 @@ module BaseTest
       assert_equal 'test', fields['tag2'], entry
       assert_equal 5000, fields['data'], entry
       actual_seconds = timestamp_seconds(entry['timestamp'])
-      actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+      actual_nanos = timestamp_nanos(entry['timestamp'])
       assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
       assert_equal K8S_NANOS, actual_nanos, entry
       assert_equal 'WARNING', entry['severity'], entry
@@ -1979,7 +1979,7 @@ module BaseTest
         verify_default_log_entry_text(entry['textPayload'], i, entry)
         # Timestamp in 'time' field from log entry should be set properly.
         actual_seconds = timestamp_seconds(entry['timestamp'])
-        actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+        actual_nanos = timestamp_nanos(entry['timestamp'])
         assert_equal DOCKER_CONTAINER_SECONDS_EPOCH, actual_seconds, entry
         assert_equal DOCKER_CONTAINER_NANOS, actual_nanos, entry
       end
@@ -2409,7 +2409,7 @@ module BaseTest
       verify_log_entries(n, expected_params) do |entry, i|
         verify_default_log_entry_text(entry['textPayload'], i, entry)
         actual_seconds = timestamp_seconds(entry['timestamp'])
-        actual_nanos = entry_timestamp_nanos(entry['timestamp'])
+        actual_nanos = timestamp_nanos(entry['timestamp'])
         assert_equal K8S_SECONDS_EPOCH, actual_seconds, entry
         assert_equal K8S_NANOS, actual_nanos, entry
         assert_equal CONTAINER_SEVERITY, entry['severity'], entry
@@ -2783,7 +2783,7 @@ module BaseTest
     _undefined
   end
 
-  def entry_timestamp_nanos(_timestamp)
+  def timestamp_nanos(_timestamp)
     _undefined
   end
 end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -984,17 +984,13 @@ module BaseTest
             verify_default_log_entry_text(entry['textPayload'], i, entry)
             actual_seconds = timestamp_seconds(entry['timestamp'])
             actual_nanos = timestamp_nanos(entry['timestamp'])
-            assert_equal_with_default actual_seconds, expected_ts.tv_sec,
-                                      default_nano_value, entry
-            assert_equal_with_default actual_nanos, expected_ts.tv_nsec,
-                                      default_nano_value, entry do
-              # Fluentd v0.14 onwards supports nanosecond timestamp values.
-              # Added in 600 ns delta to avoid flaky tests introduced
-              # due to rounding error in double-precision floating-point numbers
-              # (to account for the missing 9 bits of precision ~ 512 ns).
-              # See http://wikipedia.org/wiki/Double-precision_floating-point_format.
-              assert_in_delta expected_ts.tv_nsec, actual_nanos, 600, entry
-            end
+            assert_equal actual_seconds, expected_ts.tv_sec, entry
+            # Fluentd v0.14 onwards supports nanosecond timestamp values.
+            # Added in 600 ns delta to avoid flaky tests introduced
+            # due to rounding error in double-precision floating-point numbers
+            # (to account for the missing 9 bits of precision ~ 512 ns).
+            # See http://wikipedia.org/wiki/Double-precision_floating-point_format.
+            assert_in_delta expected_ts.tv_nsec, actual_nanos, 600, entry
           end
         end
       end
@@ -2687,23 +2683,6 @@ module BaseTest
   # The conversions from user input to output.
   def latency_conversion
     _undefined
-    {
-      '32 s' => '32s',
-      '32s' => '32s',
-      '0.32s' => '0.320000000s',
-      ' 123 s ' => '123s',
-      '1.3442 s' => '1.344200000s',
-
-      # Test whitespace.
-      # \t: tab. \r: carriage return. \n: line break.
-      # \v: vertical whitespace. \f: form feed.
-      "\t123.5\ts\t" => '123.500000000s',
-      "\r123.5\rs\r" => '123.500000000s',
-      "\n123.5\ns\n" => '123.500000000s',
-      "\v123.5\vs\v" => '123.500000000s',
-      "\f123.5\fs\f" => '123.500000000s',
-      "\r123.5\ts\f" => '123.500000000s'
-    }
   end
 
   # This module expects the methods below to be overridden.

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -476,8 +476,7 @@ module BaseTest
     verify_log_entries(1, COMPUTE_PARAMS, 'jsonPayload') do |entry|
       fields = entry['jsonPayload']
       assert_equal 7, fields.size, entry
-      assert_equal message, fields['int_key']['1'],
-                   entry
+      assert_equal message, fields['int_key']['1'], entry
       assert_equal message, fields['int_array_key']['[1, 2, 3, 4]'], entry
       assert_equal message, fields['string_array_key']['["a", "b", "c"]'], entry
       assert_equal message, fields['hash_key']['{"some_key"=>"some_value"}'],
@@ -2660,9 +2659,7 @@ module BaseTest
         payload_fields = entry['jsonPayload']
         assert_equal input[:expected_payload].size, payload_fields.size, input
         payload_fields.each do |key, value|
-          expected = input[:expected_payload][key]
-          assert_equal expected, value,
-                       "expected: #{expected}\nactual: #{value}"
+          assert_equal input[:expected_payload][key], value
         end
       end
     end
@@ -2726,10 +2723,6 @@ module BaseTest
     assert_equal(expected_value, metric_value)
   end
 
-  def _undefined
-    raise "Method #{__callee__} is unimplemented and needs to be overridden."
-  end
-
   # Defined in specific gRPC or REST files.
   def expected_operation_message2
     _undefined
@@ -2745,5 +2738,9 @@ module BaseTest
 
   def timestamp_nanos(_timestamp)
     _undefined
+  end
+
+  def _undefined
+    raise "Method #{__callee__} is unimplemented and needs to be overridden."
   end
 end

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -845,16 +845,16 @@ module Constants
   ).freeze
 
   HTTP_REQUEST_MESSAGE = {
-    'cacheFillBytes' => 6653,
+    'cacheFillBytes' => '6653',
     'cacheHit' => true,
     'cacheLookup' => true,
     'cacheValidatedWithOriginServer' => true,
     'protocol' => 'HTTP/1.1',
     'referer' => 'http://referer/',
     'remoteIp' => '55.55.55.55',
-    'responseSize' => 65,
+    'responseSize' => '65',
     'requestMethod' => 'POST',
-    'requestSize' => 210,
+    'requestSize' => '210',
     'requestUrl' => 'http://example/',
     'serverIp' => '66.66.66.66',
     'status' => 200,
@@ -864,13 +864,13 @@ module Constants
   SOURCE_LOCATION_MESSAGE = {
     'file' => 'source/file',
     'function' => 'my_function',
-    'line' => 18
+    'line' => '18'
   }.freeze
 
   SOURCE_LOCATION_MESSAGE2 = {
     'file' => 'src/file',
     'function' => 'my_func',
-    'line' => 8
+    'line' => '8'
   }.freeze
 
   OPERATION_MESSAGE = {

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -469,15 +469,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     OPERATION_MESSAGE2
   end
 
-  def default_nano_value
-    0
-  end
-
-  def timestamp_seconds(timestamp)
-    timestamp['seconds']
-  end
-
-  def timestamp_nanos(timestamp)
-    timestamp['nanos']
+  def timestamp_parse(timestamp)
+    timestamp
   end
 end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -469,6 +469,8 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     OPERATION_MESSAGE2
   end
 
+  # Directly return the timestamp value, which should be a hash two keys:
+  # "seconds" and "nanos".
   def timestamp_parse(timestamp)
     timestamp
   end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -511,7 +511,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     timestamp['seconds']
   end
 
-  def entry_timestamp_nanos(timestamp)
+  def timestamp_nanos(timestamp)
     timestamp['nanos']
   end
 end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -408,6 +408,27 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     yield
   end
 
+  # The conversions from user input to output.
+  def latency_conversion
+    {
+      '32 s' => { 'seconds' => 32 },
+      '32s' => { 'seconds' => 32 },
+      '0.32s' => { 'nanos' => 320_000_000 },
+      ' 123 s ' => { 'seconds' => 123 },
+      '1.3442 s' => { 'seconds' => 1, 'nanos' => 344_200_000 },
+
+      # Test whitespace.
+      # \t: tab. \r: carriage return. \n: line break.
+      # \v: vertical whitespace. \f: form feed.
+      "\t123.5\ts\t" => { 'seconds' => 123, 'nanos' => 500_000_000 },
+      "\r123.5\rs\r" => { 'seconds' => 123, 'nanos' => 500_000_000 },
+      "\n123.5\ns\n" => { 'seconds' => 123, 'nanos' => 500_000_000 },
+      "\v123.5\vs\v" => { 'seconds' => 123, 'nanos' => 500_000_000 },
+      "\f123.5\fs\f" => { 'seconds' => 123, 'nanos' => 500_000_000 },
+      "\r123.5\ts\f" => { 'seconds' => 123, 'nanos' => 500_000_000 }
+    }
+  end
+
   # Create a Fluentd output test driver with the Google Cloud Output plugin.
   def create_driver(conf = APPLICATION_DEFAULT_CONFIG,
                     tag = 'test',
@@ -444,31 +465,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     end
   end
 
-  # Get the fields of the payload.
-  def get_fields(payload)
-    payload
-  end
-
-  # Get the value of a struct field.
-  def get_struct(field)
-    field
-  end
-
-  # Get the value of a string field.
-  def get_string(field)
-    field
-  end
-
-  # Get the value of a number field.
-  def get_number(field)
-    field
-  end
-
-  # The null value.
-  def null_value
-    nil
-  end
-
   # Convert certain fields to strings for compatibility between gRPC and REST.
   # See more details in:
   # https://github.com/google/google-api-ruby-client/issues/619.
@@ -503,10 +499,19 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     OPERATION_MESSAGE2
   end
 
-  # Both expected and actual are Ruby hashes that represent JSON
-  # objects.
-  # This method has a different implementation at the gRPC side.
-  def assert_hash_equal_json(expected, actual)
-    assert_equal expected, actual, "expected: #{expected}\nactual: #{actual}"
+  def enable_grpc
+    false
+  end
+
+  def default_nano_value
+    0
+  end
+
+  def entry_timestamp_seconds(timestamp)
+    timestamp['seconds']
+  end
+
+  def entry_timestamp_nanos(timestamp)
+    timestamp['nanos']
   end
 end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -507,7 +507,7 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     0
   end
 
-  def entry_timestamp_seconds(timestamp)
+  def timestamp_seconds(timestamp)
     timestamp['seconds']
   end
 

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -469,10 +469,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     OPERATION_MESSAGE2
   end
 
-  def enable_grpc
-    false
-  end
-
   def default_nano_value
     0
   end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -465,36 +465,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     end
   end
 
-  # Convert certain fields to strings for compatibility between gRPC and REST.
-  # See more details in:
-  # https://github.com/google/google-api-ruby-client/issues/619.
-  def convert_subfields_to_strings(full_hash, fields_to_convert)
-    full_hash.merge(Hash[
-      fields_to_convert.collect do |field_name|
-        [field_name, full_hash[field_name].to_s]
-      end
-    ])
-  end
-
-  # 'responseSize', 'requestSize', and 'cacheFillBytes' are Integers in the gRPC
-  # protos, yet Strings in REST API client libraries.
-  def http_request_message
-    convert_subfields_to_strings(
-      HTTP_REQUEST_MESSAGE, %w(cacheFillBytes responseSize requestSize))
-  end
-
-  # 'line' is an Integer in the gRPC proto, yet a String in the REST API client.
-  def source_location_message
-    convert_subfields_to_strings(
-      SOURCE_LOCATION_MESSAGE, ['line'])
-  end
-
-  # 'line' is an Integer in the gRPC proto, yet a String in the REST API client.
-  def source_location_message2
-    convert_subfields_to_strings(
-      SOURCE_LOCATION_MESSAGE2, ['line'])
-  end
-
   def expected_operation_message2
     OPERATION_MESSAGE2
   end

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -495,7 +495,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     nil
   end
 
-  def entry_timestamp_seconds(timestamp)
+  def timestamp_seconds(timestamp)
     Time.parse(timestamp).tv_sec
   end
 

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -499,7 +499,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     Time.parse(timestamp).tv_sec
   end
 
-  def entry_timestamp_nanos(timestamp)
+  def timestamp_nanos(timestamp)
     Time.parse(timestamp).tv_nsec
   end
 end

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -469,18 +469,6 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     end
   end
 
-  def http_request_message
-    HTTP_REQUEST_MESSAGE
-  end
-
-  def source_location_message
-    SOURCE_LOCATION_MESSAGE
-  end
-
-  def source_location_message2
-    SOURCE_LOCATION_MESSAGE2
-  end
-
   def expected_operation_message2
     # 'last' is a boolean field with false as default value. Protobuf omit
     # fields with default values during deserialization.

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -477,6 +477,8 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     OPERATION_MESSAGE2.reject { |k, _| k == 'last' }
   end
 
+  # Parse timestamp and convert it to a hash with two keys:
+  # "seconds" and "nanos".
   def timestamp_parse(timestamp)
     parsed = Time.parse(timestamp)
     {

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -260,6 +260,8 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     end
   end
 
+  # TODO(qingling128): Verify if we need this on the REST side and add it if
+  # needed.
   def test_struct_payload_non_utf8_log
     setup_gce_metadata_stubs
     setup_logging_stubs do
@@ -280,7 +282,7 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       assert_equal 5000, fields['non_utf8 key'], entry
       assert_equal 'test non utf8', fields['nested_struct']['non_utf8 key'],
                    entry
-      assert_equal nil, fields['null_field'], entry
+      assert_nil fields['null_field'], entry
     end
   end
 
@@ -473,10 +475,6 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     # 'last' is a boolean field with false as default value. Protobuf omit
     # fields with default values during deserialization.
     OPERATION_MESSAGE2.reject { |k, _| k == 'last' }
-  end
-
-  def enable_grpc
-    true
   end
 
   def default_nano_value

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -477,15 +477,11 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
     OPERATION_MESSAGE2.reject { |k, _| k == 'last' }
   end
 
-  def default_nano_value
-    nil
-  end
-
-  def timestamp_seconds(timestamp)
-    Time.parse(timestamp).tv_sec
-  end
-
-  def timestamp_nanos(timestamp)
-    Time.parse(timestamp).tv_nsec
+  def timestamp_parse(timestamp)
+    parsed = Time.parse(timestamp)
+    {
+      'seconds' => parsed.tv_sec,
+      'nanos' => parsed.tv_nsec
+    }
   end
 end


### PR DESCRIPTION
This includes the fix for https://github.com/protocolbuffers/protobuf/pull/5752 and 
 https://github.com/googleapis/google-cloud-ruby/issues/2876.

google-protobuf 3.7.0 introduced a bunch of JSON serialization/deserialization changes: https://github.com/googleapis/google-cloud-ruby/issues/2900. That broke a ton of our unit tests (https://travis-ci.org/GoogleCloudPlatform/fluent-plugin-google-cloud/jobs/563866931 comes with 15 failures, 41 errors).