### PR TITLE
Mute "warning: already initialized constant" message in the log.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -45,13 +45,16 @@ module Google
     # Patch the gcloud command used by googleauth to avoid spamming stderr.
     module CredentialsLoader
       # Set $VERBOSE to nil to mute the following warning:
-      # "warning: already initialized constant Google::Auth::CredentialsLoader
-      # ::GCLOUD_CONFIG_COMMAND"
+      # "warning: already initialized constant
+      # Google::Auth::CredentialsLoader::GCLOUD_CONFIG_COMMAND".
       warn_level = $VERBOSE
-      $VERBOSE = nil
-      GCLOUD_CONFIG_COMMAND =
-        'config config-helper --format json --verbosity none'.freeze
-      $VERBOSE = warn_level
+      begin
+        $VERBOSE = nil
+        GCLOUD_CONFIG_COMMAND =
+          'config config-helper --format json --verbosity none'.freeze
+      ensure
+        $VERBOSE = warn_level
+      end
     end
   end
 end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -40,12 +40,13 @@ module Google
   end
 end
 
-# Patch the gcloud command used by googleauth to avoid spamming stderr.
 module Google
   module Auth
+    # Patch the gcloud command used by googleauth to avoid spamming stderr.
     module CredentialsLoader
       # Set $VERBOSE to nil to mute the following warning:
-      # "warning: already initialized constant Google::Auth::CredentialsLoader::GCLOUD_CONFIG_COMMAND"
+      # "warning: already initialized constant Google::Auth::CredentialsLoader
+      # ::GCLOUD_CONFIG_COMMAND"
       warn_level = $VERBOSE
       $VERBOSE = nil
       GCLOUD_CONFIG_COMMAND =

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -44,8 +44,13 @@ end
 module Google
   module Auth
     module CredentialsLoader
+      # Set $VERBOSE to nil to mute the following warning:
+      # "warning: already initialized constant Google::Auth::CredentialsLoader::GCLOUD_CONFIG_COMMAND"
+      warn_level = $VERBOSE
+      $VERBOSE = nil
       GCLOUD_CONFIG_COMMAND =
         'config config-helper --format json --verbosity none'.freeze
+      $VERBOSE = warn_level
     end
   end
 end


### PR DESCRIPTION
This message is not harmful, just a bit misleading when debugging other issues.

```
/opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-0.7.13/lib/fluent/plugin/out_google_cloud.rb:47: warning: already initialized constant Google::Auth::CredentialsLoader::GCLOUD_CONFIG_COMMAND
/opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/googleauth-0.8.1/lib/googleauth/credentials_loader.rb:52: warning: previous definition of GCLOUD_CONFIG_COMMAND was here
```