### PR TITLE
Mute 'Failed to set monitored resource labels for gce_instance' error for GKE On-Prem.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1236,8 +1236,10 @@ module Fluent
 
       {}
     rescue StandardError => e
-      @log.error "Failed to set monitored resource labels for #{type}: ",
-                 error: e
+      if [Platform::GCE, Platform::EC2].include?(@platform)
+        @log.error "Failed to set monitored resource labels for #{type}: ",
+                   error: e
+      end
       {}
     end
 


### PR DESCRIPTION
We are seeing misleading errors when logging agent starts up:

[Error]
```
2019-06-23 00:53:53 +0000 [info]: [google_cloud] use_metadata_service is false; not detecting platform
2019-06-23 00:53:53 +0000 [error]: [google_cloud] Failed to set monitored resource labels for gce_instance:  error_class=RuntimeError error="Cannot construct a gce_instance resource without vm_id and zone"
```