### PR TITLE
Completely disable gcloud credential lookups rather than silence them.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -48,6 +48,11 @@ module Google
       warn_level = $VERBOSE
       begin
         $VERBOSE = nil
+        # These constants are used to invoke gcloud on Linux and Windows,
+        # respectively. Ideally, we would have overridden
+        # CredentialsLoader.load_gcloud_project_id, but we cannot catch it
+        # before it's invoked via "require 'googleauth'". So we override the
+        # constants instead.
         GCLOUD_POSIX_COMMAND = '/bin/true'.freeze
         GCLOUD_WINDOWS_COMMAND = 'cd .'.freeze
         GCLOUD_CONFIG_COMMAND = ''.freeze

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -42,16 +42,15 @@ end
 
 module Google
   module Auth
-    # Patch the gcloud command used by googleauth to avoid spamming stderr.
+    # Disable gcloud lookup in googleauth to avoid picking up its project id.
     module CredentialsLoader
-      # Set $VERBOSE to nil to mute the following warning:
-      # "warning: already initialized constant
-      # Google::Auth::CredentialsLoader::GCLOUD_CONFIG_COMMAND".
+      # Set $VERBOSE to nil to mute the "already initialized constant" warnings.
       warn_level = $VERBOSE
       begin
         $VERBOSE = nil
-        GCLOUD_CONFIG_COMMAND =
-          'config config-helper --format json --verbosity none'.freeze
+        GCLOUD_POSIX_COMMAND = '/bin/true'.freeze
+        GCLOUD_WINDOWS_COMMAND = 'cd .'.freeze
+        GCLOUD_CONFIG_COMMAND = ''.freeze
       ensure
         $VERBOSE = warn_level
       end


### PR DESCRIPTION
This is a follow-on to #310 (and #319).