### PR TITLE
Upgrade dependency versions.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -22,7 +22,7 @@ eos
   gem.add_runtime_dependency 'fluentd', '1.6.3'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.9'
   gem.add_runtime_dependency 'googleauth', '0.9.0'
-  gem.add_runtime_dependency 'google-api-client', '0.28.4'
+  gem.add_runtime_dependency 'google-api-client', '0.30.8'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.0'
   gem.add_runtime_dependency 'google-protobuf', '3.9.0'
   gem.add_runtime_dependency 'grpc', '1.22.0'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -23,7 +23,7 @@ eos
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.9'
   gem.add_runtime_dependency 'googleauth', '0.9.0'
   gem.add_runtime_dependency 'google-api-client', '0.30.8'
-  gem.add_runtime_dependency 'google-cloud-logging', '1.6.0'
+  gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
   gem.add_runtime_dependency 'google-protobuf', '3.9.0'
   gem.add_runtime_dependency 'grpc', '1.22.0'
   gem.add_runtime_dependency 'json', '2.1.0'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -20,7 +20,7 @@ eos
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency 'fluentd', '1.6.3'
-  gem.add_runtime_dependency 'googleapis-common-protos', '1.3.7'
+  gem.add_runtime_dependency 'googleapis-common-protos', '1.3.9'
   gem.add_runtime_dependency 'googleauth', '0.8.1'
   gem.add_runtime_dependency 'google-api-client', '0.28.4'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.0'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -21,7 +21,7 @@ eos
 
   gem.add_runtime_dependency 'fluentd', '1.6.3'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.9'
-  gem.add_runtime_dependency 'googleauth', '0.8.1'
+  gem.add_runtime_dependency 'googleauth', '0.9.0'
   gem.add_runtime_dependency 'google-api-client', '0.28.4'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.0'
   gem.add_runtime_dependency 'google-protobuf', '3.9.0'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -19,7 +19,7 @@ eos
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'fluentd', '1.4.2'
+  gem.add_runtime_dependency 'fluentd', '1.6.3'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.7'
   gem.add_runtime_dependency 'googleauth', '0.8.1'
   gem.add_runtime_dependency 'google-api-client', '0.28.4'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -26,7 +26,7 @@ eos
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
   gem.add_runtime_dependency 'google-protobuf', '3.9.0'
   gem.add_runtime_dependency 'grpc', '1.22.0'
-  gem.add_runtime_dependency 'json', '2.1.0'
+  gem.add_runtime_dependency 'json', '2.2.0'
 
   gem.add_development_dependency 'mocha', '~> 1.1'
   gem.add_development_dependency 'prometheus-client', '~> 0.8.0'


### PR DESCRIPTION
* Upgrade Fluentd to 1.6.3.
* Upgrade google-api-client to 0.30.8.
* Upgrade google-cloud-logging to 1.6.6.
* Upgrade googleapis-common-protos to 1.3.9.
* Upgrade googleauth to 0.9.0.
* Upgrade json to 2.2.0.