### PR TITLE
Introduced new plugin for memory profiling

### DIFF
--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -1,0 +1,52 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'fluent/plugin/input'
+
+module Fluent
+  # Dump out all live objects to a json file.
+  class ObjectSpaceDumpInput < Fluent::Plugin::Input
+    Fluent::Plugin.register_input('object_space_dump', self)
+
+    helpers :timer
+
+    def initialize
+      super
+    end
+
+    config_param :emit_interval, :time, default: 60
+    config_param :tag, :string
+
+    def multi_workers_ready?
+      true
+    end
+
+    def start
+      super
+
+      timer_execute(:object_space_dump_input, @emit_interval,
+                    &method(:on_timer))
+    end
+
+    def on_timer
+      GC.start
+      file = Tempfile.new(['heap', '.json'])
+      begin
+        log.info 'dumping object space to', filepath: file.path, tag: @tag
+        ObjectSpace.dump_all(output: file)
+      ensure
+        file.close
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -44,7 +44,8 @@ module Fluent
 
     def on_timer
       GC.start
-      file = Tempfile.new(['heap', '.json'])
+      # The create method doesn't delete the file.
+      file = Tempfile.create(['heap', '.json'])
       begin
         log.info 'dumping object space to', filepath: file.path
         ObjectSpace.dump_all(output: file)

--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -27,7 +27,9 @@ module Fluent
       ObjectSpace.trace_object_allocations_start
     end
 
-    config_param :emit_interval, :time, default: 60
+    # These files are large. If you increase this interval, make sure you have
+    # enough disk space.
+    config_param :emit_interval, :time, default: 3600
 
     def multi_workers_ready?
       true

--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -22,6 +22,8 @@ module Fluent
 
     def initialize
       super
+
+      ObjectSpace.trace_object_allocations_start
     end
 
     config_param :emit_interval, :time, default: 60

--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -49,7 +49,9 @@ module Fluent
       # Use Tempfile.create to open the file, in order to preserve the file.
       file = Tempfile.create(['heap-' + fluentd_worker_id.to_s + '-', '.json'])
       begin
-        log.info 'dumping object space to', filepath: file.path, worker: fluentd_worker_id
+        log.info 'dumping object space to',
+                 filepath: file.path,
+                 worker: fluentd_worker_id
         ObjectSpace.dump_all(output: file)
       ensure
         file.close

--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 require 'fluent/plugin/input'
+require 'objspace'
 
 module Fluent
   # Dump out all live objects to a json file.

--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -36,6 +36,8 @@ module Fluent
     def start
       super
 
+      # Dump during startup. The timer only fires after @emit_interval.
+      on_timer
       timer_execute(:object_space_dump_input, @emit_interval,
                     &method(:on_timer))
     end

--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -15,7 +15,8 @@ require 'fluent/plugin/input'
 require 'objspace'
 
 module Fluent
-  # Dump out all live objects to a json file.
+  # Dump out all live objects to json files. Each file is a snapshot of the Ruby
+  # heap at that time. See http://tmm1.net/ruby21-objspace/ for more details.
   class ObjectSpaceDumpInput < Fluent::Plugin::Input
     Fluent::Plugin.register_input('object_space_dump', self)
 
@@ -27,8 +28,8 @@ module Fluent
       ObjectSpace.trace_object_allocations_start
     end
 
-    # These files are large. If you increase this interval, make sure you have
-    # enough disk space.
+    # Make sure you have enough disk space, because these files are large
+    # (roughly 50MB).
     config_param :emit_interval, :time, default: 3600
 
     def multi_workers_ready?

--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -46,10 +46,10 @@ module Fluent
 
     def on_timer
       GC.start
-      # The create method doesn't delete the file.
-      file = Tempfile.create(['heap', '.json'])
+      # Use Tempfile.create to open the file, in order to preserve the file.
+      file = Tempfile.create(['heap-' + fluentd_worker_id.to_s + '-', '.json'])
       begin
-        log.info 'dumping object space to', filepath: file.path
+        log.info 'dumping object space to', filepath: file.path, worker: fluentd_worker_id
         ObjectSpace.dump_all(output: file)
       ensure
         file.close

--- a/lib/fluent/plugin/in_object_space_dump.rb
+++ b/lib/fluent/plugin/in_object_space_dump.rb
@@ -28,7 +28,6 @@ module Fluent
     end
 
     config_param :emit_interval, :time, default: 60
-    config_param :tag, :string
 
     def multi_workers_ready?
       true
@@ -45,7 +44,7 @@ module Fluent
       GC.start
       file = Tempfile.new(['heap', '.json'])
       begin
-        log.info 'dumping object space to', filepath: file.path, tag: @tag
+        log.info 'dumping object space to', filepath: file.path
         ObjectSpace.dump_all(output: file)
       ensure
         file.close


### PR DESCRIPTION
It uses the objspace module documented here: http://tmm1.net/ruby21-objspace/

Here are more examples on how to use this data: https://samsaffron.com/archive/2015/03/31/debugging-memory-leaks-in-ruby

@StevenYCChou the PRNG chose you as the reviewer.
@qingling128 please review for Ruby readability and general "does this go in this package".