### PR TITLE
Upgraded to Prometheus client 0.10.0.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -29,7 +29,7 @@ eos
   gem.add_runtime_dependency 'json', '2.2.0'
 
   gem.add_development_dependency 'mocha', '1.9.0'
-  gem.add_development_dependency 'prometheus-client', '0.9.0'
+  gem.add_development_dependency 'prometheus-client', '0.10.0'
   # TODO(qingling128): Upgrade rake to 11.0+ after the following issues are
   # fixed because rake (11.0+) requires ALL variables to be explicitly
   # initialized.

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -508,22 +508,29 @@ module Fluent
         registry = Monitoring::MonitoringRegistryFactory.create @monitoring_type
         @successful_requests_count = registry.counter(
           :stackdriver_successful_requests_count,
-          'A number of successful requests to the Stackdriver Logging API')
+          labels: [:grpc, :code],
+          docstring: 'A number of successful requests to the Stackdriver '\
+                     'Logging API')
         @failed_requests_count = registry.counter(
           :stackdriver_failed_requests_count,
-          'A number of failed requests to the Stackdriver Logging API,'\
-            ' broken down by the error code')
+          labels: [:grpc, :code],
+          docstring: 'A number of failed requests to the Stackdriver Logging '\
+            'API, broken down by the error code')
         @ingested_entries_count = registry.counter(
           :stackdriver_ingested_entries_count,
-          'A number of log entries ingested by Stackdriver Logging')
+          labels: [:grpc, :code],
+          docstring: 'A number of log entries ingested by Stackdriver Logging')
         @dropped_entries_count = registry.counter(
           :stackdriver_dropped_entries_count,
-          'A number of log entries dropped by the Stackdriver output plugin')
+          labels: [:grpc, :code],
+          docstring: 'A number of log entries dropped by the Stackdriver '\
+                     'output plugin')
         @retried_entries_count = registry.counter(
           :stackdriver_retried_entries_count,
-          'The number of log entries that failed to be ingested by the'\
-            ' Stackdriver output plugin due to a transient error and were'\
-            ' retried')
+          labels: [:grpc, :code],
+          docstring: 'The number of log entries that failed to be ingested by '\
+                     'the Stackdriver output plugin due to a transient error '\
+                     'and were retried')
         @ok_code = @use_grpc ? GRPC::Core::StatusCodes::OK : 200
       end
 
@@ -2363,36 +2370,40 @@ module Fluent
     # Increment the metric for the number of successful requests.
     def increment_successful_requests_count
       return unless @successful_requests_count
-      @successful_requests_count.increment(grpc: @use_grpc, code: @ok_code)
+      @successful_requests_count.increment(
+        labels: { grpc: @use_grpc, code: @ok_code })
     end
 
     # Increment the metric for the number of failed requests, labeled by
     # the provided status code.
     def increment_failed_requests_count(code)
       return unless @failed_requests_count
-      @failed_requests_count.increment(grpc: @use_grpc, code: code)
+      @failed_requests_count.increment(
+        labels: { grpc: @use_grpc, code: code })
     end
 
     # Increment the metric for the number of log entries, successfully
     # ingested by the Stackdriver Logging API.
     def increment_ingested_entries_count(count)
       return unless @ingested_entries_count
-      @ingested_entries_count.increment({ grpc: @use_grpc, code: @ok_code },
-                                        count)
+      @ingested_entries_count.increment(
+        labels: { grpc: @use_grpc, code: @ok_code }, by: count)
     end
 
     # Increment the metric for the number of log entries that were dropped
     # and not ingested by the Stackdriver Logging API.
     def increment_dropped_entries_count(count, code)
       return unless @dropped_entries_count
-      @dropped_entries_count.increment({ grpc: @use_grpc, code: code }, count)
+      @dropped_entries_count.increment(
+        labels: { grpc: @use_grpc, code: code }, by: count)
     end
 
     # Increment the metric for the number of log entries that were dropped
     # and not ingested by the Stackdriver Logging API.
     def increment_retried_entries_count(count, code)
       return unless @retried_entries_count
-      @retried_entries_count.increment({ grpc: @use_grpc, code: code }, count)
+      @retried_entries_count.increment(
+        labels: { grpc: @use_grpc, code: code }, by: count)
     end
   end
 end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -2718,7 +2718,7 @@ module BaseTest
                      # Sum up all metric values regardless of the labels.
                      metric.values.values.reduce(0.0, :+)
                    else
-                     metric.get(labels)
+                     metric.get(labels: labels)
                    end
     assert_equal(expected_value, metric_value)
   end

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -88,15 +88,11 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     assert_prometheus_metric_value(
       :stackdriver_successful_requests_count, 1, grpc: false, code: 200)
     assert_prometheus_metric_value(
-      :stackdriver_failed_requests_count, 0, grpc: false)
-    assert_prometheus_metric_value(
       :stackdriver_ingested_entries_count, 1, grpc: false, code: 200)
     assert_prometheus_metric_value(
       :stackdriver_dropped_entries_count, 2, grpc: false, code: 3)
     assert_prometheus_metric_value(
       :stackdriver_dropped_entries_count, 1, grpc: false, code: 7)
-    assert_prometheus_metric_value(
-      :stackdriver_retried_entries_count, 0, grpc: false)
     assert_requested(:post, WRITE_LOG_ENTRIES_URI, times: 1)
   end
 
@@ -120,8 +116,6 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
       :stackdriver_ingested_entries_count, 0, grpc: false, code: 200)
     assert_prometheus_metric_value(
       :stackdriver_dropped_entries_count, 1, grpc: false, code: 400)
-    assert_prometheus_metric_value(
-      :stackdriver_retried_entries_count, 0, grpc: false)
     assert_requested(:post, WRITE_LOG_ENTRIES_URI, times: 1)
   end
 

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -112,8 +112,6 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       assert_prometheus_metric_value(
         :stackdriver_dropped_entries_count, 1,
         grpc: true, code: GRPC::Core::StatusCodes::PERMISSION_DENIED)
-      assert_prometheus_metric_value(
-        :stackdriver_retried_entries_count, 0, grpc: true)
     end
   end
 
@@ -140,8 +138,6 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       assert_prometheus_metric_value(
         :stackdriver_dropped_entries_count, 1,
         grpc: true, code: GRPC::Core::StatusCodes::INVALID_ARGUMENT)
-      assert_prometheus_metric_value(
-        :stackdriver_retried_entries_count, 0, grpc: true)
     end
   end
 


### PR DESCRIPTION
The client library had a breaking change to its API. I decided to fix this as pre-work for making the monitoring code also support OpenCensus, so we can use the new API as the common API for the abstraction on top of both.