### PR TITLE
Remove waits on test start-up.

### DIFF
--- a/test/plugin/test_driver.rb
+++ b/test/plugin/test_driver.rb
@@ -18,6 +18,17 @@ require 'fluent/test/input_test'
 
 module Fluent
   module Test
+    class BufferedOutputTestDriver < InputTestDriver
+      @@run_method = BufferedOutputTestDriver.instance_method(:run)
+      def run(num_waits = 0)
+        return @@run_method.bind(self).call(num_waits)
+      end
+    end
+  end
+end
+
+module Fluent
+  module Test
     # Similar to the standard BufferedOutputTestDriver, but allows multiple tags
     # to exist in one chunk.
     class MultiTagBufferedOutputTestDriver < InputTestDriver
@@ -33,7 +44,7 @@ module Fluent
         self
       end
 
-      def run(num_waits = 10)
+      def run(num_waits = 0)
         result = nil
         super(num_waits) do
           chunk = @instance.buffer.generate_chunk(

--- a/test/plugin/test_driver.rb
+++ b/test/plugin/test_driver.rb
@@ -18,12 +18,14 @@ require 'fluent/test/input_test'
 
 module Fluent
   module Test
+    # rubocop:disable Style/ClassVars
     class BufferedOutputTestDriver < InputTestDriver
       @@run_method = BufferedOutputTestDriver.instance_method(:run)
       def run(num_waits = 0)
         @@run_method.bind(self).call(num_waits)
       end
     end
+    # rubocop:enable Style/ClassVars
   end
 end
 

--- a/test/plugin/test_driver.rb
+++ b/test/plugin/test_driver.rb
@@ -21,7 +21,7 @@ module Fluent
     class BufferedOutputTestDriver < InputTestDriver
       @@run_method = BufferedOutputTestDriver.instance_method(:run)
       def run(num_waits = 0)
-        return @@run_method.bind(self).call(num_waits)
+        @@run_method.bind(self).call(num_waits)
       end
     end
   end


### PR DESCRIPTION
This brings down text execution from >5 minutes to <20 seconds. The tests all pass, hopefully they don't become flaky. Upstream is unclear about why the waits were needed, I'll follow up with them: https://github.com/fluent/fluentd/blob/master/lib/fluent/test/base.rb#L64-L75

Upstream discussion (just posted): https://groups.google.com/d/topic/fluentd/ze7YY1ue40s/discussion