### PR TITLE
Backported to prometheus client 0.9.0

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -29,7 +29,9 @@ eos
   gem.add_runtime_dependency 'json', '2.2.0'
 
   gem.add_development_dependency 'mocha', '1.9.0'
-  gem.add_development_dependency 'prometheus-client', '0.10.0'
+  # Keep this the same as in
+  # https://github.com/fluent/fluent-plugin-prometheus/blob/master/fluent-plugin-prometheus.gemspec
+  gem.add_development_dependency 'prometheus-client', '< 0.10'
   # TODO(qingling128): Upgrade rake to 11.0+ after the following issues are
   # fixed because rake (11.0+) requires ALL variables to be explicitly
   # initialized.

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -13,9 +13,27 @@
 # limitations under the License.
 
 module Monitoring
+  # Base class for the counter.
+  class BaseCounter
+    def increment(_labels, _count)
+      nil
+    end
+  end
+
+  # Prometheus implementation of counters.
+  class PrometheusCounter < BaseCounter
+    def initialize(prometheus_counter)
+      @counter = prometheus_counter
+    end
+
+    def increment(by: 1, labels: {})
+      @counter.increment(labels, by)
+    end
+  end
+
   # Base class for the monitoring registry.
   class BaseMonitoringRegistry
-    def counter(_name, _desc)
+    def counter(_name, _labels, _docstring)
       nil
     end
   end
@@ -33,10 +51,10 @@ module Monitoring
     end
 
     # Exception-driven behavior to avoid synchronization errors.
-    def counter(name, desc)
-      return @registry.counter(name, desc)
+    def counter(name, labels, docstring)
+      return PrometheusCounter.new(@registry.counter(name, docstring, labels))
     rescue Prometheus::Client::Registry::AlreadyRegisteredError
-      return @registry.get(name)
+      return PrometheusCounter.new(@registry.get(name))
     end
   end
 

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -15,7 +15,7 @@
 module Monitoring
   # Base class for the counter.
   class BaseCounter
-    def increment(_labels, _count)
+    def increment(_by: 1, _labels: {})
       nil
     end
   end

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -508,29 +508,27 @@ module Fluent
         registry = Monitoring::MonitoringRegistryFactory.create @monitoring_type
         @successful_requests_count = registry.counter(
           :stackdriver_successful_requests_count,
-          labels: [:grpc, :code],
-          docstring: 'A number of successful requests to the Stackdriver '\
-                     'Logging API')
+          [:grpc, :code],
+          'A number of successful requests to the Stackdriver Logging API')
         @failed_requests_count = registry.counter(
           :stackdriver_failed_requests_count,
-          labels: [:grpc, :code],
-          docstring: 'A number of failed requests to the Stackdriver Logging '\
-            'API, broken down by the error code')
+          [:grpc, :code],
+          'A number of failed requests to the Stackdriver Logging '\
+          'API, broken down by the error code')
         @ingested_entries_count = registry.counter(
           :stackdriver_ingested_entries_count,
-          labels: [:grpc, :code],
-          docstring: 'A number of log entries ingested by Stackdriver Logging')
+          [:grpc, :code],
+          'A number of log entries ingested by Stackdriver Logging')
         @dropped_entries_count = registry.counter(
           :stackdriver_dropped_entries_count,
-          labels: [:grpc, :code],
-          docstring: 'A number of log entries dropped by the Stackdriver '\
-                     'output plugin')
+          [:grpc, :code],
+          'A number of log entries dropped by the Stackdriver output plugin')
         @retried_entries_count = registry.counter(
           :stackdriver_retried_entries_count,
-          labels: [:grpc, :code],
-          docstring: 'The number of log entries that failed to be ingested by '\
-                     'the Stackdriver output plugin due to a transient error '\
-                     'and were retried')
+          [:grpc, :code],
+          'The number of log entries that failed to be ingested by '\
+          'the Stackdriver output plugin due to a transient error '\
+          'and were retried')
         @ok_code = @use_grpc ? GRPC::Core::StatusCodes::OK : 200
       end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -2718,7 +2718,7 @@ module BaseTest
                      # Sum up all metric values regardless of the labels.
                      metric.values.values.reduce(0.0, :+)
                    else
-                     metric.get(labels: labels)
+                     metric.get(labels)
                    end
     assert_equal(expected_value, metric_value)
   end


### PR DESCRIPTION
I didn't simply revert #342 because I want to preserve the changes in out_google_cloud for my my follow-up change to support OpenCensus. It will also be much easier to support prometheus client 0.10.0 on top of this change:

- Add the `labels:`, `docstring:`, and `by:` prefixes to the `counter.increment` and `registry.counter` calls in monitoring.rb.
- Add the `labels:` prefix to the assert_prometheus metric method in base_test.rb.