### PR TITLE
Fixed Prometheus counter instantiation

### DIFF
--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -75,7 +75,11 @@ module Monitoring
 
     # Exception-driven behavior to avoid synchronization errors.
     def counter(name, labels, docstring)
-      return PrometheusCounter.new(@registry.counter(name, docstring, labels))
+      # When we upgrade to Prometheus client 0.10.0 or higher, pass the labels in the
+      # metric constructor.
+      # The 'labels' field in Prometheus client 0.9.0 has a different function and
+      # will not work as intended.
+      return PrometheusCounter.new(@registry.counter(name, docstring))
     rescue Prometheus::Client::Registry::AlreadyRegisteredError
       return PrometheusCounter.new(@registry.get(name))
     end

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -74,11 +74,11 @@ module Monitoring
     end
 
     # Exception-driven behavior to avoid synchronization errors.
-    def counter(name, labels, docstring)
-      # When we upgrade to Prometheus client 0.10.0 or higher, pass the labels in the
-      # metric constructor.
-      # The 'labels' field in Prometheus client 0.9.0 has a different function and
-      # will not work as intended.
+    def counter(name, _labels, docstring)
+      # When we upgrade to Prometheus client 0.10.0 or higher, pass the
+      # labels in the metric constructor. The 'labels' field in
+      # Prometheus client 0.9.0 has a different function and will not
+      # work as intended.
       return PrometheusCounter.new(@registry.counter(name, docstring))
     rescue Prometheus::Client::Registry::AlreadyRegisteredError
       return PrometheusCounter.new(@registry.get(name))


### PR DESCRIPTION
The labels argument was in an unexpected format that none of our tests caught, and it's undocumented for the client library 0.9.0 that we use. Once we upgrade to 0.10.0, we should revert this change.