### PR TITLE
Update layout for README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,10 +1,8 @@
 = Google Cloud Logging plugin for {fluentd}[http://github.com/fluent/fluentd]
 
 fluent-plugin-google-cloud gem includes two plugins:
-1. A {filter plugin for fluentd}[https://docs.fluentd.org/filter]
-that embeds insertIds into log entries to guarantee order and uniqueness.
-2. An {output plugin for fluentd}[https://docs.fluentd.org/output]
-which sends logs to the {Stackdriver Logging API}[https://cloud.google.com/logging/docs/api/].
+1. A {filter plugin for fluentd}[https://docs.fluentd.org/filter] that embeds insertIds into log entries to guarantee order and uniqueness.
+2. An {output plugin for fluentd}[https://docs.fluentd.org/output] which sends logs to the {Stackdriver Logging API}[https://cloud.google.com/logging/docs/api/].
 
 This is an official Google Ruby gem.
 


### PR DESCRIPTION
While I have been using this plugin for a while, I've been always confused by the first paragraph of README:

Screenshot:

![Screenshot 2019-11-04 01 24 13](https://user-images.githubusercontent.com/14349/68089256-e82d8d80-fea1-11e9-8d40-f3d049d1a4bf.png)

I suggest combining them into single lines and make it looks like screenshot below:

![image](https://user-images.githubusercontent.com/14349/68089274-19a65900-fea2-11e9-9cda-0c8db61e0d5a.png)
