### PR TITLE
Emit the uptime metric

### DIFF
--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -15,8 +15,7 @@
 module Monitoring
   # Base class for the counter.
   class BaseCounter
-    def increment(_by: 1, _labels: {})
-      nil
+    def increment(*)
     end
   end
 
@@ -54,7 +53,7 @@ module Monitoring
     end
 
     def counter(_name, _labels, _docstring)
-      nil
+      BaseCounter.new
     end
 
     def export

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -254,7 +254,7 @@ module Fluent
 
     PLUGIN_NAME = 'Fluentd Google Cloud Logging plugin'.freeze
 
-    # Follows semver format.
+    # Follows semver.org format.
     PLUGIN_VERSION = begin
       # Extract plugin version from file path.
       match_data = __FILE__.match(
@@ -487,7 +487,7 @@ module Fluent
       @retried_entries_count = nil
 
       @ok_code = nil
-      @uptime_time = 0
+      @uptime_time = Time.now.to_i
     end
 
     def configure(conf)
@@ -560,8 +560,10 @@ module Fluent
                     .create(@monitoring_type, @project_id, @resource)
         # Export metrics every 60 seconds.
         timer_execute(:export_metrics, 60) { @registry.export }
+        # Uptime should be a gauge, but the metric definition is a counter and
+        # we can't change it.
         @uptime_metric = @registry.counter(
-          :uptime, [:version], 'Uptime of Monitoring agent')
+          :uptime, [:version], 'Uptime of Logging agent')
         update_uptime
         timer_execute(:update_uptime, 1) { update_uptime }
         @successful_requests_count = @registry.counter(

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -269,12 +269,9 @@ module Fluent
           proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
             spec.version.to_s
           end
-        if matching_version
-          matching_version
-        else
-          # Return a valid but obviously wrong value.
-          '0.0.0-unknown'
-        end
+        # If no matching version was found, return a valid but obviously wrong
+        # value.
+        matching_version || '0.0.0-unknown'
       end
     end.freeze
 
@@ -787,7 +784,7 @@ module Fluent
     end
 
     def self.version_string
-      @version_string || "google-fluentd/#{PLUGIN_VERSION}"
+      @version_string ||= "google-fluentd/#{PLUGIN_VERSION}"
     end
 
     def update_uptime

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -254,6 +254,7 @@ module Fluent
 
     PLUGIN_NAME = 'Fluentd Google Cloud Logging plugin'.freeze
 
+    # Follows semver format.
     PLUGIN_VERSION = begin
       # Extract plugin version from file path.
       match_data = __FILE__.match(
@@ -268,7 +269,12 @@ module Fluent
           proc { |spec,| __FILE__.include?(spec.full_gem_path) }) do |spec,|
             spec.version.to_s
           end
-        matching_version
+        if matching_version
+          matching_version
+        else
+          # Return a valid but obviously wrong value.
+          '0.0.0-unknown'
+        end
       end
     end.freeze
 
@@ -481,6 +487,7 @@ module Fluent
       @retried_entries_count = nil
 
       @ok_code = nil
+      @uptime_time = 0
     end
 
     def configure(conf)
@@ -553,6 +560,10 @@ module Fluent
                     .create(@monitoring_type, @project_id, @resource)
         # Export metrics every 60 seconds.
         timer_execute(:export_metrics, 60) { @registry.export }
+        @uptime_metric = @registry.counter(
+          :uptime, [:version], 'Uptime of Monitoring agent')
+        update_uptime
+        timer_execute(:update_uptime, 1) { update_uptime }
         @successful_requests_count = @registry.counter(
           :stackdriver_successful_requests_count,
           [:grpc, :code],
@@ -771,6 +782,18 @@ module Fluent
 
     def multi_workers_ready?
       true
+    end
+
+    def self.version_string
+      @version_string || "google-fluentd/#{PLUGIN_VERSION}"
+    end
+
+    def update_uptime
+      now = Time.now.to_i
+      @uptime_metric.increment(
+        by: now - @uptime_time,
+        labels: { version: Fluent::GoogleCloudOutput.version_string })
+      @uptime_time = now
     end
 
     private

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -484,7 +484,7 @@ module Fluent
       @retried_entries_count = nil
 
       @ok_code = nil
-      @uptime_time = Time.now.to_i
+      @uptime_update_time = Time.now.to_i
     end
 
     def configure(conf)
@@ -790,9 +790,9 @@ module Fluent
     def update_uptime
       now = Time.now.to_i
       @uptime_metric.increment(
-        by: now - @uptime_time,
+        by: now - @uptime_update_time,
         labels: { version: Fluent::GoogleCloudOutput.version_string })
-      @uptime_time = now
+      @uptime_update_time = now
     end
 
     private

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -2055,7 +2055,6 @@ module BaseTest
       clear_metrics
       d = create_driver(config)
       d.run
-      exception_count = 0
       begin
         # Retry to avoid time races.
         retries ||= 0

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -2053,15 +2053,16 @@ module BaseTest
       [ENABLE_OPENCENSUS_CONFIG, method(:assert_opencensus_metric_value)]
     ].each do |config, assert_metric_value|
       clear_metrics
+      start_time = Time.now.to_i
       d = create_driver(config)
       d.run
       begin
-        # Retry to avoid time races.
+        # Retry to protect from time races.
         retries ||= 0
-        now = Time.now.to_i
+        expected = Time.now.to_i - start_time
         d.instance.update_uptime
         assert_metric_value.call(
-          :uptime, now, version: Fluent::GoogleCloudOutput.version_string)
+          :uptime, expected, version: Fluent::GoogleCloudOutput.version_string)
       rescue Test::Unit::AssertionFailedError
         retry if (retries += 1) < 3
       end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -2046,6 +2046,21 @@ module BaseTest
     end
   end
 
+  def test_uptime_metric
+    setup_gce_metadata_stubs
+    [
+      [ENABLE_PROMETHEUS_CONFIG, method(:assert_prometheus_metric_value)],
+      [ENABLE_OPENCENSUS_CONFIG, method(:assert_opencensus_metric_value)]
+    ].each do |config, assert_metric_value|
+      clear_metrics
+      d = create_driver(config)
+      now = Time.now.to_i # Racey. Apologies for flakes.
+      d.run
+      assert_metric_value.call(
+        :uptime, now, version: Fluent::GoogleCloudOutput.version_string)
+    end
+  end
+
   private
 
   def stub_metadata_request(metadata_path, response_body)


### PR DESCRIPTION
The format of version is `google-fluentd/1.2.3-foo`. It's quite inconvenient in Ruby to extract the Linux distro in a portable manner like we do in the collectd build system. @igorpeshansky in case you know that we already have this, but otherwise feel free to ignore.