### PR TITLE
Handle an edge case for timestamp adjustment (December 31).

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -713,7 +713,10 @@ module Fluent
             end
           end
 
-          ts_secs, ts_nanos = compute_timestamp(record, time)
+          ts_secs, ts_nanos, timestamp = compute_timestamp(record, time)
+          ts_secs, ts_nanos = adjust_timestamp_if_invalid(timestamp, Time.now) \
+            if @adjust_invalid_timestamps && timestamp
+
           severity = compute_severity(
             entry_level_resource.type, record, entry_level_common_labels)
 
@@ -1652,7 +1655,6 @@ module Fluent
     end
 
     def compute_timestamp(record, time)
-      current_time = Time.now
       if record.key?('timestamp') &&
          record['timestamp'].is_a?(Hash) &&
          record['timestamp'].key?('seconds') &&
@@ -1704,38 +1706,43 @@ module Fluent
                    ts_nanos
                  end
 
-      if @adjust_invalid_timestamps && timestamp
-        # Adjust timestamps from the future.
-        # The base case is:
-        # 0. The parsed timestamp is less than one day into the future.
-        # This is allowed by the API, and should be left unchanged.
-        #
-        # Beyond that, there are two cases:
-        # 1. The parsed timestamp is later in the current year:
-        # This can happen when system log lines from previous years are missing
-        # the year, so the date parser assumes the current year.
-        # We treat these lines as coming from last year. This could label
-        # 2-year-old logs incorrectly, but this probably isn't super important.
-        #
-        # 2. The parsed timestamp is past the end of the current year:
-        # Since the year is different from the current year, this isn't the
-        # missing year in system logs. It is unlikely that users explicitly
-        # write logs at a future date. This could result from an unsynchronized
-        # clock on a VM, or some random value being parsed as the timestamp.
-        # We reset the timestamp on those lines to the default value and let the
-        # downstream API handle it.
-        next_year = Time.mktime(current_time.year + 1)
-        one_day_later = current_time.to_datetime.next_day.to_time
-        if timestamp < one_day_later # Case 0.
-          # Leave the timestamp as-is.
-        elsif timestamp >= next_year # Case 2.
-          ts_secs = 0
-          ts_nanos = 0
-        else # Case 1.
-          adjusted_timestamp = timestamp.to_datetime.prev_year.to_time
-          ts_secs = adjusted_timestamp.tv_sec
-          # The value of ts_nanos should not change when subtracting a year.
-        end
+      [ts_secs, ts_nanos, timestamp]
+    end
+
+    # Adjust timestamps from the future.
+    # The base case is:
+    # 0. The parsed timestamp is less than one day into the future.
+    # This is allowed by the API, and should be left unchanged.
+    #
+    # Beyond that, there are two cases:
+    # 1. The parsed timestamp is later in the current year:
+    # This can happen when system log lines from previous years are missing
+    # the year, so the date parser assumes the current year.
+    # We treat these lines as coming from last year. This could label
+    # 2-year-old logs incorrectly, but this probably isn't super important.
+    #
+    # 2. The parsed timestamp is past the end of the current year:
+    # Since the year is different from the current year, this isn't the
+    # missing year in system logs. It is unlikely that users explicitly
+    # write logs at a future date. This could result from an unsynchronized
+    # clock on a VM, or some random value being parsed as the timestamp.
+    # We reset the timestamp on those lines to the default value and let the
+    # downstream API handle it.
+    def adjust_timestamp_if_invalid(timestamp, current_time)
+      ts_secs = timestamp.tv_sec
+      ts_nanos = timestamp.tv_nsec
+
+      next_year = Time.mktime(current_time.year + 1)
+      one_day_later = current_time.to_datetime.next_day.to_time
+      if timestamp < one_day_later # Case 0.
+        # Leave the timestamp as-is.
+      elsif timestamp >= next_year # Case 2.
+        ts_secs = 0
+        ts_nanos = 0
+      else # Case 1.
+        adjusted_timestamp = timestamp.to_datetime.prev_year.to_time
+        ts_secs = adjusted_timestamp.tv_sec
+        # The value of ts_nanos should not change when subtracting a year.
       end
 
       [ts_secs, ts_nanos]

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -943,93 +943,206 @@ module BaseTest
     end
   end
 
-  def test_timestamps
+  def test_compute_timestamp
     setup_gce_metadata_stubs
-    current_time = Time.now
+    d = create_driver(APPLICATION_DEFAULT_CONFIG)
+
+    compute_timestamp = lambda do |driver, record, time|
+      driver.instance.send(:compute_timestamp, record, time)
+    end
+
+    current_time = Time.new(2019, 12, 29, 10, 23, 35, '-08:00')
     one_day_later = current_time.to_datetime.next_day.to_time
     just_under_one_day_later = one_day_later - 1
     next_year = Time.mktime(current_time.year + 1)
     one_second_before_next_year = next_year - 1
     one_second_into_next_year = next_year + 1
     one_day_into_next_year = next_year.to_datetime.next_day.to_time
-    # Note: these tests behave differently on December 31.
-    # TODO: use patched Time.now instead of messing with the current time.
-    adjust_unless_within_a_day = lambda do |original_ts, new_ts|
-      return new_ts unless original_ts < one_day_later
-      # Timestamps less than one day away should be left alone.
-      original_ts
+
+    [
+      Time.at(123_456.789),
+      Time.at(0),
+      current_time,
+      just_under_one_day_later,
+      one_second_before_next_year,
+      next_year,
+      one_second_into_next_year,
+      one_day_into_next_year
+    ].each do |ts|
+      # Use record collection time.
+      ts_secs, ts_nanos, actual_ts = compute_timestamp[d, {
+        'message' => ''
+      }, ts.to_f]
+      assert_timestamp_matches ts, ts_secs, ts_nanos, actual_ts.iso8601
+
+      # Use the (deprecated) timeNanos key.
+      ts_secs, ts_nanos, actual_ts = compute_timestamp[d, {
+        'message' => '',
+        'timeNanos' => ts.tv_sec * 1_000_000_000 + ts.tv_nsec
+      }, 1.0]
+      assert_timestamp_matches ts, ts_secs, ts_nanos, actual_ts.iso8601
+
+      # Use the structured timestamp key.
+      ts_secs, ts_nanos, actual_ts = compute_timestamp[d, {
+        'message' => '',
+        'timestamp' => { 'seconds' => ts.tv_sec, 'nanos' => ts.tv_nsec }
+      }, 1.0]
+      assert_timestamp_matches ts, ts_secs, ts_nanos, actual_ts.iso8601
+
+      # Use the timestampSeconds/timestampNanos keys.
+      ts_secs, ts_nanos, actual_ts = compute_timestamp[d, {
+        'message' => '',
+        'timestampSeconds' => ts.tv_sec,
+        'timestampNanos' => ts.tv_nsec
+      }, 1.0]
+      assert_timestamp_matches ts, ts_secs, ts_nanos, actual_ts.iso8601
+
+      # Use the string timestampSeconds/timestampNanos keys.
+      ts_secs, ts_nanos, actual_ts = compute_timestamp[d, {
+        'message' => '',
+        'timestampSeconds' => ts.tv_sec.to_s,
+        'timestampNanos' => ts.tv_nsec.to_s
+      }, 1.0]
+      assert_timestamp_matches ts, ts_secs, ts_nanos, actual_ts.iso8601
     end
-    adjusted_to_last_year =
-      adjust_unless_within_a_day[
-        one_second_before_next_year,
-        one_second_before_next_year.to_datetime.prev_year.to_time]
-    zero_for_next_year = adjust_unless_within_a_day[next_year, Time.at(0)]
-    zero_for_next_year_plus_one =
-      adjust_unless_within_a_day[one_second_into_next_year, Time.at(0)]
+  end
+
+  def test_adjust_timestamp
+    setup_gce_metadata_stubs
+    d = create_driver(APPLICATION_DEFAULT_CONFIG)
+
+    adjust_timestamp_if_invalid = lambda do |driver, timestamp, current_time|
+      driver.instance.send(:adjust_timestamp_if_invalid, timestamp,
+                           current_time)
+    end
+
+    december_29 = Time.new(2019, 12, 29, 10, 23, 35, '-08:00')
+    december_31 = Time.new(2019, 12, 31, 10, 23, 35, '-08:00')
+    january_1 = Time.new(2020, 1, 1, 10, 23, 35, '-08:00')
+
     {
-      APPLICATION_DEFAULT_CONFIG => {
-        Time.at(123_456.789) => Time.at(123_456.789),
-        Time.at(0) => Time.at(0),
-        current_time => current_time,
-        just_under_one_day_later => just_under_one_day_later,
-        one_second_before_next_year => adjusted_to_last_year,
-        next_year => zero_for_next_year,
-        one_second_into_next_year => zero_for_next_year_plus_one,
-        one_day_into_next_year => Time.at(0)
-      },
-      NO_ADJUST_TIMESTAMPS_CONFIG => {
-        Time.at(123_456.789) => Time.at(123_456.789),
-        Time.at(0) => Time.at(0),
-        current_time => current_time,
-        just_under_one_day_later => just_under_one_day_later,
-        one_second_before_next_year => one_second_before_next_year,
-        next_year => next_year,
-        one_second_into_next_year => one_second_into_next_year,
-        one_day_into_next_year => one_day_into_next_year
-      }
-    }.each do |config, timestamps|
+      # December 29, 2019 (normal operation).
+      december_29 => begin
+        one_day_later = Time.new(2019, 12, 30, 10, 23, 35, '-08:00')
+        one_day_a_year_earlier = Time.new(2018, 12, 30, 10, 23, 35, '-08:00')
+        just_under_one_day_later = Time.new(2019, 12, 30, 10, 23, 34, '-08:00')
+        next_year = Time.new(2020, 1, 1, 0, 0, 0, '-08:00')
+        one_second_before_next_year =
+          Time.new(2019, 12, 31, 11, 59, 59, '-08:00')
+        one_second_before_this_year =
+          Time.new(2018, 12, 31, 11, 59, 59, '-08:00')
+        one_second_into_next_year = Time.new(2020, 1, 1, 0, 0, 1, '-08:00')
+        one_day_into_next_year = Time.new(2020, 1, 2, 0, 0, 0, '-08:00')
+        {
+          Time.at(123_456.789) => Time.at(123_456.789),
+          Time.at(0) => Time.at(0),
+          december_29 => december_29,
+          one_day_later => one_day_a_year_earlier,
+          just_under_one_day_later => just_under_one_day_later,
+          one_second_before_next_year => one_second_before_this_year,
+          next_year => Time.at(0),
+          one_second_into_next_year => Time.at(0),
+          one_day_into_next_year => Time.at(0)
+        }
+      end,
+      # January 1, 2020 (normal operation).
+      january_1 => begin
+        one_day_later = Time.new(2020, 1, 2, 10, 23, 35, '-08:00')
+        one_day_a_year_earlier = Time.new(2019, 1, 2, 10, 23, 35, '-08:00')
+        just_under_one_day_later = Time.new(2020, 1, 2, 10, 23, 34, '-08:00')
+        next_year = Time.new(2021, 1, 1, 0, 0, 0, '-08:00')
+        one_second_before_next_year =
+          Time.new(2020, 12, 31, 11, 59, 59, '-08:00')
+        one_second_before_this_year =
+          Time.new(2019, 12, 31, 11, 59, 59, '-08:00')
+        one_second_into_next_year = Time.new(2021, 1, 1, 0, 0, 1, '-08:00')
+        one_day_into_next_year = Time.new(2021, 1, 2, 0, 0, 0, '-08:00')
+        {
+          Time.at(123_456.789) => Time.at(123_456.789),
+          Time.at(0) => Time.at(0),
+          january_1 => january_1,
+          one_day_later => one_day_a_year_earlier,
+          just_under_one_day_later => just_under_one_day_later,
+          one_second_before_next_year => one_second_before_this_year,
+          next_year => Time.at(0),
+          one_second_into_next_year => Time.at(0),
+          one_day_into_next_year => Time.at(0)
+        }
+      end,
+      # December 31, 2019 (next day overlaps new year).
+      december_31 => begin
+        one_day_later = Time.new(2020, 1, 1, 10, 23, 35, '-08:00')
+        just_under_one_day_later = Time.new(2020, 1, 1, 10, 23, 34, '-08:00')
+        next_year = Time.new(2020, 1, 1, 0, 0, 0, '-08:00')
+        one_second_before_next_year =
+          Time.new(2019, 12, 31, 11, 59, 59, '-08:00')
+        one_second_into_next_year = Time.new(2020, 1, 1, 0, 0, 1, '-08:00')
+        one_day_into_next_year = Time.new(2020, 1, 2, 0, 0, 0, '-08:00')
+        {
+          Time.at(123_456.789) => Time.at(123_456.789),
+          Time.at(0) => Time.at(0),
+          december_31 => december_31,
+          one_day_later => Time.at(0), # Falls into the next year.
+          just_under_one_day_later => just_under_one_day_later,
+          one_second_before_next_year => one_second_before_next_year,
+          next_year => next_year,
+          one_second_into_next_year => one_second_into_next_year,
+          one_day_into_next_year => Time.at(0)
+        }
+      end
+    }.each do |current_time, timestamps|
       timestamps.each do |ts, expected_ts|
-        emit_index = 0
-        setup_logging_stubs do
-          @logs_sent = []
-          d = create_driver(config)
-          # Test the "native" fluentd timestamp as well as our nanosecond tags.
-          d.emit({ 'message' => log_entry(emit_index) }, ts.to_f)
-          emit_index += 1
-          d.emit('message' => log_entry(emit_index),
-                 'timeNanos' => ts.tv_sec * 1_000_000_000 + ts.tv_nsec)
-          emit_index += 1
-          d.emit('message' => log_entry(emit_index),
-                 'timestamp' => { 'seconds' => ts.tv_sec,
-                                  'nanos' => ts.tv_nsec })
-          emit_index += 1
-          d.emit('message' => log_entry(emit_index),
-                 'timestampSeconds' => ts.tv_sec,
-                 'timestampNanos' => ts.tv_nsec)
-          emit_index += 1
-          d.emit('message' => log_entry(emit_index),
-                 'timestampSeconds' => ts.tv_sec.to_s,
-                 'timestampNanos' => ts.tv_nsec.to_s)
-          emit_index += 1
-          d.run
-          verify_log_entries(emit_index, COMPUTE_PARAMS) do |entry, i|
-            verify_default_log_entry_text(entry['textPayload'], i, entry)
-            actual_timestamp = timestamp_parse(entry['timestamp'])
-            assert_equal expected_ts.tv_sec, actual_timestamp['seconds'], entry
-            # Fluentd v0.14 onwards supports nanosecond timestamp values.
-            # Added in 600 ns delta to avoid flaky tests introduced
-            # due to rounding error in double-precision floating-point numbers
-            # (to account for the missing 9 bits of precision ~ 512 ns).
-            # See http://wikipedia.org/wiki/Double-precision_floating-point_format.
-            assert_in_delta expected_ts.tv_nsec, actual_timestamp['nanos'],
-                            600, entry
-          end
+        ts_secs, ts_nanos = adjust_timestamp_if_invalid[d, ts, current_time]
+        adjusted_ts = Time.at(ts_secs, ts_nanos / 1_000.0)
+        assert_timestamp_matches expected_ts, ts_secs, ts_nanos,
+                                 adjusted_ts.iso8601
+      end
+    end
+  end
+
+  def test_log_timestamps
+    setup_gce_metadata_stubs
+    current_time = Time.now
+    {
+      # Verify that timestamps make it through.
+      Time.at(123_456.789) => Time.at(123_456.789),
+      Time.at(0) => Time.at(0),
+      current_time => current_time
+    }.each do |ts, expected_ts|
+      emit_index = 0
+      setup_logging_stubs do
+        @logs_sent = []
+        d = create_driver(APPLICATION_DEFAULT_CONFIG)
+        # Test the "native" fluentd timestamp as well as our nanosecond tags.
+        d.emit({ 'message' => log_entry(emit_index) }, ts.to_f)
+        emit_index += 1
+        d.emit('message' => log_entry(emit_index),
+               'timeNanos' => ts.tv_sec * 1_000_000_000 + ts.tv_nsec)
+        emit_index += 1
+        d.emit('message' => log_entry(emit_index),
+               'timestamp' => { 'seconds' => ts.tv_sec,
+                                'nanos' => ts.tv_nsec })
+        emit_index += 1
+        d.emit('message' => log_entry(emit_index),
+               'timestampSeconds' => ts.tv_sec,
+               'timestampNanos' => ts.tv_nsec)
+        emit_index += 1
+        d.emit('message' => log_entry(emit_index),
+               'timestampSeconds' => ts.tv_sec.to_s,
+               'timestampNanos' => ts.tv_nsec.to_s)
+        emit_index += 1
+        d.run
+        verify_log_entries(emit_index, COMPUTE_PARAMS) do |entry, i|
+          verify_default_log_entry_text(entry['textPayload'], i, entry)
+          actual_timestamp = timestamp_parse(entry['timestamp'])
+          assert_timestamp_matches expected_ts, actual_timestamp['seconds'],
+                                   actual_timestamp['nanos'], entry
         end
       end
     end
   end
 
-  def test_malformed_timestamp
+  def test_malformed_timestamp_field
     setup_gce_metadata_stubs
     setup_logging_stubs do
       d = create_driver
@@ -2763,6 +2876,17 @@ module BaseTest
   # a plain equal. e.g. assert_in_delta.
   def assert_equal_with_default(_field, _expected_value, _default_value, _entry)
     _undefined
+  end
+
+  # Compare the timestamp seconds and nanoseconds with the expected timestamp.
+  def assert_timestamp_matches(expected_ts, ts_secs, ts_nanos, entry)
+    assert_equal expected_ts.tv_sec, ts_secs, entry
+    # Fluentd v0.14 onwards supports nanosecond timestamp values.
+    # Added in 600 ns delta to avoid flaky tests introduced
+    # due to rounding error in double-precision floating-point numbers
+    # (to account for the missing 9 bits of precision ~ 512 ns).
+    # See http://wikipedia.org/wiki/Double-precision_floating-point_format.
+    assert_in_delta expected_ts.tv_nsec, ts_nanos, 600, entry
   end
 
   def assert_prometheus_metric_value(metric_name, expected_value, labels = {})

--- a/test/plugin/constants.rb
+++ b/test/plugin/constants.rb
@@ -274,10 +274,6 @@ module Constants
     split_logs_by_tag true
   ).freeze
 
-  NO_ADJUST_TIMESTAMPS_CONFIG = %(
-    adjust_invalid_timestamps false
-  ).freeze
-
   ENABLE_PROMETHEUS_CONFIG = %(
     enable_monitoring true
     monitoring_type prometheus


### PR DESCRIPTION
Fix a bug in timestamp adjustment (we should accept timestamps that are up to one day in the future, regardless of the date).
Fix broken tests that were computing the wrong expected values on December 31.