### PR TITLE
Use Ruby's builtin time parser.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -76,11 +76,11 @@ module GRPC
   extend FluentLogger
 end
 
+require 'strptime'
 # Cripple the nurse/strptime gem used by FluentD's TimeParser class in
 # lib/fluent/time.rb. We found this gem to be slower than the builtin Ruby
 # parser in recent versions of Ruby. Fortunately FluentD will fall back to the
 # builtin parser.
-require 'strptime'
 class Strptime
   def self.new(_)
     nil

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -76,14 +76,14 @@ module GRPC
   extend FluentLogger
 end
 
-require 'strptime'
-# Cripple the nurse/strptime gem used by FluentD's TimeParser class in
+# Disable the nurse/strptime gem used by FluentD's TimeParser class in
 # lib/fluent/time.rb. We found this gem to be slower than the builtin Ruby
 # parser in recent versions of Ruby. Fortunately FluentD will fall back to the
 # builtin parser.
+require 'strptime'
+# Dummy Strptime class.
 class Strptime
   def self.new(_)
-    nil
   end
 end
 

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -76,6 +76,17 @@ module GRPC
   extend FluentLogger
 end
 
+# Cripple the nurse/strptime gem used by FluentD's TimeParser class in
+# lib/fluent/time.rb. We found this gem to be slower than the builtin Ruby
+# parser in recent versions of Ruby. Fortunately FluentD will fall back to the
+# builtin parser.
+require 'strptime'
+class Strptime
+  def self.new(_)
+    nil
+  end
+end
+
 module Fluent
   # fluentd output plugin for the Stackdriver Logging API
   class GoogleCloudOutput < BufferedOutput


### PR DESCRIPTION
This reduces CPU usage in micro and macro benchmarks of our GKE setup by 20-30%. I ran the macro benchmark with Ruby 2.6.3, and the micro benchmark with Ruby 2.5.7 and 2.6.3.

Thanks to @igorpeshansky for the tip on how to monkey patch the method.

```ruby
# strptime-builtin.rb 
require 'time'
1000000.times { Time.strptime("1227 20:39:23.1234 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
, "%m%d %H:%M:%S.%N") }                                                                                                                               

# strptime-nurse.rb 
require 'strptime'
strptime = Strptime.new("%m%d %H:%M:%S.%N")
1000000.times { strptime.exec("1227 20:39:23.1234 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
) }                                                                                                                                                   
```

```
% time ruby strptime-builtin.rb 
ruby strptime-builtin.rb  4.85s user 1.89s system 99% cpu 6.738 total
% time ruby strptime-nurse.rb  
ruby strptime-nurse.rb  2.66s user 6.30s system 99% cpu 8.961 total
```

![ink](https://user-images.githubusercontent.com/7148392/71730131-65786e80-2e0f-11ea-8a78-0e22536a6eae.png)


I'll follow up with a change for the FluentD code upstream.