### PR TITLE
Add config param for Google Cloud Monitoring service address.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -27,10 +27,10 @@ eos
   gem.add_runtime_dependency 'google-protobuf', '3.9.0'
   gem.add_runtime_dependency 'grpc', '1.22.0'
   gem.add_runtime_dependency 'json', '2.2.0'
+  gem.add_runtime_dependency 'opencensus', '0.5.0'
+  gem.add_runtime_dependency 'opencensus-stackdriver', '0.3.1'
 
   gem.add_development_dependency 'mocha', '1.9.0'
-  gem.add_development_dependency 'opencensus', '0.5.0'
-  gem.add_development_dependency 'opencensus-stackdriver', '0.3.0'
   # Keep this the same as in
   # https://github.com/fluent/fluent-plugin-prometheus/blob/master/fluent-plugin-prometheus.gemspec
   gem.add_development_dependency 'prometheus-client', '< 0.10'

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -49,7 +49,7 @@ module Monitoring
 
   # Base class for the monitoring registry.
   class BaseMonitoringRegistry
-    def initialize(_project_id, _monitored_resource)
+    def initialize(_project_id, _monitored_resource, _gcm_service_address)
     end
 
     def counter(_name, _labels, _docstring)
@@ -68,7 +68,7 @@ module Monitoring
       'prometheus'
     end
 
-    def initialize(_project_id, _monitored_resource)
+    def initialize(_project_id, _monitored_resource, _gcm_service_address)
       super
       require 'prometheus/client'
       @registry = Prometheus::Client.registry
@@ -92,7 +92,7 @@ module Monitoring
       'opencensus'
     end
 
-    def initialize(project_id, monitored_resource)
+    def initialize(project_id, monitored_resource, gcm_service_address)
       super
       require 'opencensus'
       require 'opencensus-stackdriver'
@@ -102,7 +102,9 @@ module Monitoring
         project_id: project_id,
         metric_prefix: 'agent.googleapis.com/agent',
         resource_type: monitored_resource.type,
-        resource_labels: monitored_resource.labels)
+        resource_labels: monitored_resource.labels,
+        gcm_service_address: gcm_service_address
+      )
       OpenCensus.configure do |c|
         c.stats.exporter = @exporter
       end
@@ -148,9 +150,9 @@ module Monitoring
       @known_registry_types.key?(name)
     end
 
-    def self.create(name, project_id, monitored_resource)
+    def self.create(name, project_id, monitored_resource, gcm_service_address)
       registry = @known_registry_types[name] || BaseMonitoringRegistry
-      registry.new(project_id, monitored_resource)
+      registry.new(project_id, monitored_resource, gcm_service_address)
     end
   end
 

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -477,6 +477,10 @@ module Fluent
     # the server is not created.
     config_param :statusz_port, :integer, :default => 0
 
+    # Override for the Google Cloud Monitoring service hostname, or
+    # `nil` to leave as the default.
+    config_param :gcm_service_address, :string, :default => nil
+
     # rubocop:enable Style/HashSyntax
 
     # TODO: Add a log_name config option rather than just using the tag?
@@ -571,7 +575,8 @@ module Fluent
                     'there will be no metrics'
         end
         @registry = Monitoring::MonitoringRegistryFactory
-                    .create(@monitoring_type, @project_id, @resource)
+                    .create(@monitoring_type, @project_id, @resource,
+                            @gcm_service_address)
         # Export metrics every 60 seconds.
         timer_execute(:export_metrics, 60) { @registry.export }
         # Uptime should be a gauge, but the metric definition is a counter and


### PR DESCRIPTION
This allows us to override the address to use a non-production endpoint.

Tested: Built gem, installed on VM, updated google-fluentd.conf to
override gcm_service_address, restarted google-fluentd, observed no
errors in logs.