### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -10,7 +10,7 @@ eos
   gem.homepage      =
     'https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud'
   gem.license       = 'Apache-2.0'
-  gem.version       = '0.7.31'
+  gem.version       = '0.8.0'
   gem.authors       = ['Stackdriver Agents Team']
   gem.email         = ['stackdriver-agents@google.com']
   gem.required_ruby_version = Gem::Requirement.new('>= 2.2')


### PR DESCRIPTION
Minor version bump due to:
- #371 : partial_success flag deprecated
- #375 : docker monitored resources deprecated
- #376 : metadata agent support deprecated