### PR TITLE
Replace deprecated Engine.msgpack_factory method with new MessagePackFactory.engine_factory method.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1909,7 +1909,11 @@ module Fluent
     end
 
     def format(tag, time, record)
-      Fluent::Engine.msgpack_factory.packer.write([tag, time, record]).to_s
+      Fluent::MessagePackFactory
+        .engine_factory
+        .packer
+        .write([tag, time, record])
+        .to_s
     end
 
     # Given a tag, returns the corresponding valid tag if possible, or nil if


### PR DESCRIPTION
From https://github.com/fluent/fluentd/issues/2871

Fluentd v1.7.4 has Fluent:: MessagePackFactory.engine_factory which is same as the . Fluent::Engine.msgpack_factory
https://github.com/fluent/fluentd/blob/v1.7.4/lib/fluent/msgpack_factory.rb#L38
