### PR TITLE
Remove fake sensitive user data in comments to get rid of warnings.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1575,7 +1575,7 @@ module Fluent
       # Recognizes IAM format (account@project-name.iam.gserviceaccount.com)
       # as well as the legacy format with a project number at the front of the
       # string, terminated by a dash (-) which is not part of the ID, i.e.:
-      # 270694816269-1l1r2hb813leuppurdeik0apglbs80sv.apps.googleusercontent.com
+      # <PROJECTD_ID>-<OTHER_PARTS>.apps.googleusercontent.com
       def self.extract_project_id(str)
         [/^.*@(?<project_id>.+)\.iam\.gserviceaccount\.com/,
          /^(?<project_id>\d+)-/].each do |exp|

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -1575,7 +1575,7 @@ module Fluent
       # Recognizes IAM format (account@project-name.iam.gserviceaccount.com)
       # as well as the legacy format with a project number at the front of the
       # string, terminated by a dash (-) which is not part of the ID, i.e.:
-      # <PROJECTD_ID>-<OTHER_PARTS>.apps.googleusercontent.com
+      # <PROJECT_ID>-<OTHER_PARTS>.apps.googleusercontent.com
       def self.extract_project_id(str)
         [/^.*@(?<project_id>.+)\.iam\.gserviceaccount\.com/,
          /^(?<project_id>\d+)-/].each do |exp|


### PR DESCRIPTION
This fixes the newly enforced git-secrets integration warning:

```
[ERROR] Matched one or more prohibited patterns

Possible mitigations:

- Mark false positives as allowed using: git config --add secrets.allowed ...

- Mark false positives as allowed by adding regular expressions to .gitallowed at repository's root directory

- List your configured patterns: git config --get-all secrets.patterns

- List your configured allowed patterns: git config --get-all secrets.allowed

- List your configured allowed patterns in .gitallowed at repository's root directory

- Use --no-verify if this is a one-time false positive

F0805 16:41:47.656311   77047 google_hook.go:84] git-secrets failed with error: exit status 1
```