### PR TITLE
Switch to using the gke_container for legacy GKE resources.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -103,7 +103,7 @@ module Fluent
       }.freeze
       GKE_CONSTANTS = {
         service: 'container.googleapis.com',
-        resource_type: 'container',
+        resource_type: 'gke_container',
         extra_resource_labels: %w(namespace_id pod_id container_name),
         extra_common_labels: %w(namespace_name pod_name),
         metadata_attributes: %w(cluster-name cluster-location),


### PR DESCRIPTION
This enables writing metrics against that resource as well.

The Logging API would accept either `container` or `gke_container` as aliases.