### PR TITLE
Revert "Remove waits on test start-up. (#343)".

### DIFF
--- a/test/plugin/test_driver.rb
+++ b/test/plugin/test_driver.rb
@@ -18,19 +18,6 @@ require 'fluent/test/input_test'
 
 module Fluent
   module Test
-    # rubocop:disable Style/ClassVars
-    class BufferedOutputTestDriver < InputTestDriver
-      @@run_method = BufferedOutputTestDriver.instance_method(:run)
-      def run(num_waits = 0)
-        @@run_method.bind(self).call(num_waits)
-      end
-    end
-    # rubocop:enable Style/ClassVars
-  end
-end
-
-module Fluent
-  module Test
     # Similar to the standard BufferedOutputTestDriver, but allows multiple tags
     # to exist in one chunk.
     class MultiTagBufferedOutputTestDriver < InputTestDriver
@@ -46,7 +33,7 @@ module Fluent
         self
       end
 
-      def run(num_waits = 0)
+      def run(num_waits = 10)
         result = nil
         super(num_waits) do
           chunk = @instance.buffer.generate_chunk(


### PR DESCRIPTION
Reverts #343 to restore test waits to avoid broken tests being shown as passed.