### PR TITLE
Document the 'opencensus' monitoring_type value.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -370,7 +370,9 @@ module Fluent
     #   - 'prometheus', in this case default registry in the Prometheus
     #     client library is used, without actually exposing the endpoint
     #     to serve metrics in the Prometheus format.
-    #    - any other value will result in the absence of metrics.
+    #   - 'opencensus', in this case the OpenCensus implementation is
+    #     used to send metrics directly to Google Cloud Monitoring.
+    #   - any other value will result in the absence of metrics.
     config_param :monitoring_type, :string,
                  :default => Monitoring::PrometheusMonitoringRegistry.name
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -122,8 +122,8 @@ module BaseTest
 
   def test_configure_ignores_unknown_monitoring_type
     # Verify that driver creation succeeds when monitoring type is not
-    # "prometheus" (in which case, we simply don't record metrics),
-    # and that the counters are set to nil.
+    # "prometheus" or "opencensus" (in which case, we simply don't record
+    # metrics), and that the counters are set to nil.
     setup_gce_metadata_stubs
     create_driver(CONFIG_UNKNOWN_MONITORING_TYPE)
     assert_nil(Prometheus::Client.registry.get(
@@ -136,6 +136,21 @@ module BaseTest
                  :stackdriver_dropped_entries_count))
     assert_nil(Prometheus::Client.registry.get(
                  :stackdriver_retried_entries_count))
+    assert_nil(OpenCensus::Stats::MeasureRegistry.get(
+                 Monitoring::MetricTranslator.new(
+                   :stackdriver_successful_requests_count, {})))
+    assert_nil(OpenCensus::Stats::MeasureRegistry.get(
+                 Monitoring::MetricTranslator.new(
+                   :stackdriver_failed_requests_count, {})))
+    assert_nil(OpenCensus::Stats::MeasureRegistry.get(
+                 Monitoring::MetricTranslator.new(
+                   :stackdriver_ingested_entries_count, {})))
+    assert_nil(OpenCensus::Stats::MeasureRegistry.get(
+                 Monitoring::MetricTranslator.new(
+                   :stackdriver_dropped_entries_count, {})))
+    assert_nil(OpenCensus::Stats::MeasureRegistry.get(
+                 Monitoring::MetricTranslator.new(
+                   :stackdriver_retried_entries_count, {})))
   end
 
   def test_metadata_loading


### PR DESCRIPTION
This was omitted in #345.