### PR TITLE
Bump gem version to 0.9.0 for future releases.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -10,7 +10,7 @@ eos
   gem.homepage      =
     'https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud'
   gem.license       = 'Apache-2.0'
-  gem.version       = '0.8.8'
+  gem.version       = '0.9.0'
   gem.authors       = ['Stackdriver Agents Team']
   gem.email         = ['stackdriver-agents@google.com']
   gem.required_ruby_version = Gem::Requirement.new('>= 2.2')


### PR DESCRIPTION
Bumping minor version due to [new functionality for configuring metrics](https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/410). 