### PR TITLE
Update grpc gem dependency version to 1.31.1.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -25,7 +25,7 @@ eos
   gem.add_runtime_dependency 'google-api-client', '0.30.8'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
   gem.add_runtime_dependency 'google-protobuf', '3.12.2'
-  gem.add_runtime_dependency 'grpc', '1.30.2'
+  gem.add_runtime_dependency 'grpc', '1.31.1'
   gem.add_runtime_dependency 'json', '2.2.0'
   gem.add_runtime_dependency 'opencensus', '0.5.0'
   gem.add_runtime_dependency 'opencensus-stackdriver', '0.3.2'


### PR DESCRIPTION
Picks up https://github.com/grpc/grpc/pull/23333 that was released in the 1.31.1 gem yesterday.