### PR TITLE
Minor renaming of metrics name and label names.

### DIFF
--- a/lib/fluent/plugin/filter_analyze_config.rb
+++ b/lib/fluent/plugin/filter_analyze_config.rb
@@ -240,12 +240,12 @@ module Fluent
 
         plugin_usage = registry.counter(
           :stackdriver_enabled_plugins,
-          [:plugin_name, :is_default_plugin, :has_default_value],
+          [:plugin_name, :is_default_plugin, :has_default_config],
           'Enabled plugins')
         config_usage = registry.counter(
-          :stackdriver_config_usage,
-          [:plugin_name, :param, :is_present, :has_default_value],
-          'Parameter usage for Google Cloud plugins')
+          :stackdriver_plugin_config,
+          [:plugin_name, :param, :is_present, :has_default_config],
+          'Configuration parameter usage for plugins relevant to Google Cloud.')
         config_bool_values = registry.counter(
           :stackdriver_config_bool_values,
           [:plugin_name, :param, :value],
@@ -276,17 +276,17 @@ module Fluent
           plugin_name = default_plugin_name(e)
           if baseline_elements.key?(plugin_name)
             is_default_plugin = true
-            has_default_value = (baseline_elements[plugin_name] == e)
+            has_default_config = (baseline_elements[plugin_name] == e)
           else
             plugin_name = custom_plugin_name(e)
             is_default_plugin = false
-            has_default_value = false
+            has_default_config = false
           end
           plugin_usage.increment(
             labels: {
               plugin_name: plugin_name,
               is_default_plugin: is_default_plugin,
-              has_default_value: has_default_value,
+              has_default_config: has_default_config,
               has_ruby_snippet: embedded_ruby?(e)
             },
             by: 1)
@@ -300,7 +300,7 @@ module Fluent
                 plugin_name: e['@type'],
                 param: p,
                 is_present: e.key?(p),
-                has_default_value: (e.key?(p) &&
+                has_default_config: (e.key?(p) &&
                                     baseline_google_element.key?(p) &&
                                     e[p] == baseline_google_element[p])
               },

--- a/test/plugin/test_filter_analyze_config.rb
+++ b/test/plugin/test_filter_analyze_config.rb
@@ -59,21 +59,21 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
         1,
         plugin_name: 'source/syslog/tcp',
         is_default_plugin: true,
-        has_default_value: true,
+        has_default_config: true,
         has_ruby_snippet: false)
       assert_metric_value.call(
         :stackdriver_enabled_plugins,
         1,
         plugin_name: 'source/tail/apache-access',
         is_default_plugin: true,
-        has_default_value: true,
+        has_default_config: true,
         has_ruby_snippet: false)
       assert_metric_value.call(
         :stackdriver_enabled_plugins,
         1,
         plugin_name: 'filter/add_insert_ids',
         is_default_plugin: true,
-        has_default_value: true,
+        has_default_config: true,
         has_ruby_snippet: false)
 
       # Default plugins, with custom config.
@@ -82,7 +82,7 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
         1,
         plugin_name: 'match/google_cloud',
         is_default_plugin: true,
-        has_default_value: false,
+        has_default_config: false,
         has_ruby_snippet: false)
 
       # Custom plugins, some with embedded Ruby.
@@ -91,45 +91,45 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
         1,
         plugin_name: 'filter',
         is_default_plugin: false,
-        has_default_value: false,
+        has_default_config: false,
         has_ruby_snippet: false)
       assert_metric_value.call(
         :stackdriver_enabled_plugins,
         1,
         plugin_name: 'filter/record_transformer',
         is_default_plugin: false,
-        has_default_value: false,
+        has_default_config: false,
         has_ruby_snippet: true)
       assert_metric_value.call(
         :stackdriver_enabled_plugins,
         1,
         plugin_name: 'match/stdout',
         is_default_plugin: false,
-        has_default_value: false,
+        has_default_config: false,
         has_ruby_snippet: true)
 
       # For out_google_cloud, 3 params are present.
       assert_metric_value.call(
-        :stackdriver_config_usage,
+        :stackdriver_plugin_config,
         1,
         plugin_name: 'google_cloud',
         param: 'adjust_invalid_timestamps',
         is_present: true,
-        has_default_value: true)
+        has_default_config: true)
       assert_metric_value.call(
-        :stackdriver_config_usage,
+        :stackdriver_plugin_config,
         1,
         plugin_name: 'google_cloud',
         param: 'autoformat_stackdriver_trace',
         is_present: true,
-        has_default_value: false)
+        has_default_config: false)
       assert_metric_value.call(
-        :stackdriver_config_usage,
+        :stackdriver_plugin_config,
         1,
         plugin_name: 'google_cloud',
         param: 'coerce_to_utf8',
         is_present: true,
-        has_default_value: false)
+        has_default_config: false)
       # The remaining "google_cloud" params are not present.
       # The are no params for "detect_exceptions".
       %w(
@@ -163,12 +163,12 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
         zone
       ).each do |p|
         assert_metric_value.call(
-          :stackdriver_config_usage,
+          :stackdriver_plugin_config,
           1,
           plugin_name: 'google_cloud',
           param: p,
           is_present: false,
-          has_default_value: false)
+          has_default_config: false)
       end
 
       # We also export values for the bools.


### PR DESCRIPTION
* Rename the label name from "has_default_value" to "has_default_config".
* Rename the metrics name from "config_usage" to "plugin_config".
* Change the metrics description from "Parameter usage for Google Cloud
plugins" to "Configuration parameter usage for plugins relevant to Google
Cloud."