### PR TITLE
Fix analyze_config plugin imports.

### DIFF
--- a/lib/fluent/plugin/filter_analyze_config.rb
+++ b/lib/fluent/plugin/filter_analyze_config.rb
@@ -15,6 +15,9 @@
 require 'fileutils'
 require 'fluent/config'
 require 'fluent/config/v1_parser'
+require 'googleauth'
+require 'google/apis/logging_v2'
+require 'open-uri'
 require 'set'
 
 require_relative 'common'


### PR DESCRIPTION
Fixes a few dependency errors like this one:

```
2020-09-16 05:40:40 +0000 [warn]: analyze_config plugin: Failed to optionally analyze the google-fluentd configuration file. Proceeding anyway. Error: uninitialized constant Common::Utils::CredentialsInfo::Google. Trace: ["/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluent-plugin-google-cloud-0.10.3/lib/fluent/plugin/common.rb:354:in `project_id'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluent-plugin-google-cloud-0.10.3/lib/fluent/plugin/common.rb:175:in `get_project_id'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluent-plugin-google-cloud-0.10.3/lib/fluent/plugin/filter_analyze_config.rb:220:in `configure'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/plugin.rb:173:in `configure'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/agent.rb:154:in `add_filter'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/agent.rb:72:in `block in configure'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/agent.rb:64:in `each'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/agent.rb:64:in `configure'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/root_agent.rb:146:in `configure'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/engine.rb:105:in `configure'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/engine.rb:80:in `run_configure'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/supervisor.rb:602:in `block in run_worker'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/supervisor.rb:840:in `main_process'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/supervisor.rb:594:in `run_worker'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/lib/fluent/command/fluentd.rb:361:in `<top (required)>'", "/opt/google-fluentd/embedded/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'", "/opt/google-fluentd/embedded/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'", "/opt/google-fluentd/embedded/lib/ruby/gems/2.6.0/gems/fluentd-1.11.2/bin/fluentd:8:in `<top (required)>'", "/opt/google-fluentd/embedded/bin/fluentd:23:in `load'", "/opt/google-fluentd/embedded/bin/fluentd:23:in `<top (required)>'", "/usr/sbin/google-fluentd:7:in `load'", "/usr/sbin/google-fluentd:7:in `<main>'"]
```