### PR TITLE
Make metrics prefix parameterized in the opencensus path.

### DIFF
--- a/lib/fluent/plugin/filter_analyze_config.rb
+++ b/lib/fluent/plugin/filter_analyze_config.rb
@@ -244,17 +244,20 @@ module Fluent
           @monitoring_type, project_id, resource, @gcm_service_address)
 
         plugin_usage = registry.counter(
-          :stackdriver_enabled_plugins,
+          :enabled_plugins,
           [:plugin_name, :is_default_plugin, :has_default_config],
-          'Enabled plugins')
+          'Enabled plugins',
+          'agent.googleapis.com/agent/internal/logging/config')
         config_usage = registry.counter(
-          :stackdriver_plugin_config,
+          :plugin_config,
           [:plugin_name, :param, :is_present, :has_default_config],
-          'Configuration parameter usage for plugins relevant to Google Cloud.')
+          'Configuration parameter usage for plugins relevant to Google Cloud.',
+          'agent.googleapis.com/agent/internal/logging/config')
         config_bool_values = registry.counter(
-          :stackdriver_config_bool_values,
+          :config_bool_values,
           [:plugin_name, :param, :value],
-          'Values for bool parameters in Google Cloud plugins')
+          'Values for bool parameters in Google Cloud plugins',
+          'agent.googleapis.com/agent/internal/logging/config')
 
         config = parse_config(@google_fluentd_config_path)
         baseline_config = parse_config(@google_fluentd_baseline_config_path)

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -52,7 +52,7 @@ module Monitoring
     def initialize(_project_id, _monitored_resource, _gcm_service_address)
     end
 
-    def counter(_name, _labels, _docstring)
+    def counter(_name, _labels, _docstring, _prefix = None)
       BaseCounter.new
     end
 
@@ -75,7 +75,7 @@ module Monitoring
     end
 
     # Exception-driven behavior to avoid synchronization errors.
-    def counter(name, _labels, docstring)
+    def counter(name, _labels, docstring, _prefix = None)
       # When we upgrade to Prometheus client 0.10.0 or higher, pass the
       # labels in the metric constructor. The 'labels' field in
       # Prometheus client 0.9.0 has a different function and will not
@@ -88,6 +88,8 @@ module Monitoring
 
   # OpenCensus implementation of the monitoring registry.
   class OpenCensusMonitoringRegistry < BaseMonitoringRegistry
+    DEFAULT_PREFIX = 'agent.googleapis.com/agent'.freeze
+
     def self.name
       'opencensus'
     end
@@ -97,21 +99,27 @@ module Monitoring
       require 'opencensus'
       require 'opencensus-stackdriver'
       @log = $log # rubocop:disable Style/GlobalVars
-      @recorder = OpenCensus::Stats.ensure_recorder
-      @exporter = OpenCensus::Stats::Exporters::Stackdriver.new(
-        project_id: project_id,
-        metric_prefix: 'agent.googleapis.com/agent',
-        resource_type: monitored_resource.type,
-        resource_labels: monitored_resource.labels,
-        gcm_service_address: gcm_service_address
-      )
+      @project_id = project_id
+      @monitored_resource = monitored_resource
+      @gcm_service_address = gcm_service_address
+      @recorders = { DEFAULT_PREFIX => OpenCensus::Stats.ensure_recorder }
+      @exporters = {
+        DEFAULT_PREFIX =>
+          OpenCensus::Stats::Exporters::Stackdriver.new(
+            project_id: project_id,
+            metric_prefix: DEFAULT_PREFIX,
+            resource_type: monitored_resource.type,
+            resource_labels: monitored_resource.labels,
+            gcm_service_address: gcm_service_address
+          )
+      }
       OpenCensus.configure do |c|
-        c.stats.exporter = @exporter
+        c.stats.exporter = @exporters[DEFAULT_PREFIX]
       end
       @log.debug "OpenCensus config=#{OpenCensus.config}"
     end
 
-    def counter(name, labels, docstring)
+    def counter(name, labels, docstring, prefix = DEFAULT_PREFIX)
       translator = MetricTranslator.new(name, labels)
       measure = OpenCensus::Stats::MeasureRegistry.get(translator.name)
       if measure.nil?
@@ -121,6 +129,17 @@ module Monitoring
           description: docstring
         )
       end
+      unless @exporters.keys.include?(prefix)
+        @recorders[prefix] = OpenCensus::Stats.ensure_recorder
+        @exporters[prefix] = \
+          OpenCensus::Stats::Exporters::Stackdriver.new(
+            project_id: @project_id,
+            metric_prefix: prefix,
+            resource_type: @monitored_resource.type,
+            resource_labels: @monitored_resource.labels,
+            gcm_service_address: @gcm_service_address
+          )
+      end
       OpenCensus::Stats.create_and_register_view(
         name: translator.name,
         measure: measure,
@@ -128,11 +147,19 @@ module Monitoring
         description: docstring,
         columns: translator.view_labels.map(&:to_s)
       )
-      OpenCensusCounter.new(@recorder, measure, translator)
+      OpenCensusCounter.new(@recorders[prefix], measure, translator)
+    rescue StandardError => e
+      @log.warn "Failed to count metrics for #{name}.", error: e
+      raise e
     end
 
     def export
-      @exporter.export @recorder.views_data
+      @exporters.keys.each do |prefix|
+        @exporters[prefix].export @recorders[prefix].views_data
+      end
+    rescue StandardError => e
+      @log.warn 'Failed to export some metrics.', error: e
+      raise e
     end
   end
 

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -52,7 +52,7 @@ module Monitoring
     def initialize(_project_id, _monitored_resource, _gcm_service_address)
     end
 
-    def counter(_name, _labels, _docstring, _prefix = None)
+    def counter(_name, _labels, _docstring, _prefix)
       BaseCounter.new
     end
 
@@ -75,7 +75,7 @@ module Monitoring
     end
 
     # Exception-driven behavior to avoid synchronization errors.
-    def counter(name, _labels, docstring, _prefix = None)
+    def counter(name, _labels, docstring, _prefix)
       # When we upgrade to Prometheus client 0.10.0 or higher, pass the
       # labels in the metric constructor. The 'labels' field in
       # Prometheus client 0.9.0 has a different function and will not
@@ -88,8 +88,6 @@ module Monitoring
 
   # OpenCensus implementation of the monitoring registry.
   class OpenCensusMonitoringRegistry < BaseMonitoringRegistry
-    DEFAULT_PREFIX = 'agent.googleapis.com/agent'.freeze
-
     def self.name
       'opencensus'
     end
@@ -100,13 +98,13 @@ module Monitoring
       require 'opencensus-stackdriver'
       @log = $log # rubocop:disable Style/GlobalVars
       @project_id = project_id
-      @monitored_resource = monitored_resource
+      @metrics_monitored_resource = monitored_resource
       @gcm_service_address = gcm_service_address
       @recorders = {}
       @exporters = {}
     end
 
-    def counter(name, labels, docstring, prefix = DEFAULT_PREFIX)
+    def counter(name, labels, docstring, prefix)
       translator = MetricTranslator.new(name, labels)
       measure = OpenCensus::Stats::MeasureRegistry.get(translator.name)
       if measure.nil?
@@ -122,8 +120,8 @@ module Monitoring
           OpenCensus::Stats::Exporters::Stackdriver.new(
             project_id: @project_id,
             metric_prefix: prefix,
-            resource_type: @monitored_resource.type,
-            resource_labels: @monitored_resource.labels,
+            resource_type: @metrics_monitored_resource.type,
+            resource_labels: @metrics_monitored_resource.labels,
             gcm_service_address: @gcm_service_address
           )
       end

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -102,21 +102,8 @@ module Monitoring
       @project_id = project_id
       @monitored_resource = monitored_resource
       @gcm_service_address = gcm_service_address
-      @recorders = { DEFAULT_PREFIX => OpenCensus::Stats.ensure_recorder }
-      @exporters = {
-        DEFAULT_PREFIX =>
-          OpenCensus::Stats::Exporters::Stackdriver.new(
-            project_id: project_id,
-            metric_prefix: DEFAULT_PREFIX,
-            resource_type: monitored_resource.type,
-            resource_labels: monitored_resource.labels,
-            gcm_service_address: gcm_service_address
-          )
-      }
-      OpenCensus.configure do |c|
-        c.stats.exporter = @exporters[DEFAULT_PREFIX]
-      end
-      @log.debug "OpenCensus config=#{OpenCensus.config}"
+      @recorders = {}
+      @exporters = {}
     end
 
     def counter(name, labels, docstring, prefix = DEFAULT_PREFIX)

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -563,32 +563,38 @@ module Fluent
         # Uptime should be a gauge, but the metric definition is a counter and
         # we can't change it.
         @uptime_metric = @registry.counter(
-          :uptime, [:version], 'Uptime of Logging agent')
+          :uptime, [:version], 'Uptime of Logging agent',
+          'agent.googleapis.com/agent')
         update_uptime
         timer_execute(:update_uptime, 1) { update_uptime }
         @successful_requests_count = @registry.counter(
           :stackdriver_successful_requests_count,
           [:grpc, :code],
-          'A number of successful requests to the Stackdriver Logging API')
+          'A number of successful requests to the Stackdriver Logging API',
+          'agent.googleapis.com/agent')
         @failed_requests_count = @registry.counter(
           :stackdriver_failed_requests_count,
           [:grpc, :code],
           'A number of failed requests to the Stackdriver Logging '\
-          'API, broken down by the error code')
+          'API, broken down by the error code',
+          'agent.googleapis.com/agent')
         @ingested_entries_count = @registry.counter(
           :stackdriver_ingested_entries_count,
           [:grpc, :code],
-          'A number of log entries ingested by Stackdriver Logging')
+          'A number of log entries ingested by Stackdriver Logging',
+          'agent.googleapis.com/agent')
         @dropped_entries_count = @registry.counter(
           :stackdriver_dropped_entries_count,
           [:grpc, :code],
-          'A number of log entries dropped by the Stackdriver output plugin')
+          'A number of log entries dropped by the Stackdriver output plugin',
+          'agent.googleapis.com/agent')
         @retried_entries_count = @registry.counter(
           :stackdriver_retried_entries_count,
           [:grpc, :code],
           'The number of log entries that failed to be ingested by '\
           'the Stackdriver output plugin due to a transient error '\
-          'and were retried')
+          'and were retried',
+          'agent.googleapis.com/agent')
         @ok_code = @use_grpc ? GRPC::Core::StatusCodes::OK : 200
       end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -169,10 +169,11 @@ module BaseTest
       assert_true d.instance.instance_variable_get(:@enable_monitoring)
       registry = d.instance.instance_variable_get(:@registry)
       assert_not_nil registry
-      exporter = registry.instance_variable_get(:@exporter)
-      assert_equal 'custom_resource', exporter.resource_type, "Index #{index}"
+      monitored_resource = registry.instance_variable_get(
+        :@metrics_monitored_resource)
+      assert_equal('custom_resource', monitored_resource.type, "Index #{index}")
       assert_equal({ 'label1' => '123', 'label2' => 'abc' },
-                   exporter.resource_labels, "Index #{index}")
+                   monitored_resource.labels, "Index #{index}")
     end
   end
 

--- a/test/plugin/test_filter_analyze_config.rb
+++ b/test/plugin/test_filter_analyze_config.rb
@@ -55,21 +55,21 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
 
       # Default plugins, with default config.
       assert_metric_value.call(
-        :stackdriver_enabled_plugins,
+        :enabled_plugins,
         1,
         plugin_name: 'source/syslog/tcp',
         is_default_plugin: true,
         has_default_config: true,
         has_ruby_snippet: false)
       assert_metric_value.call(
-        :stackdriver_enabled_plugins,
+        :enabled_plugins,
         1,
         plugin_name: 'source/tail/apache-access',
         is_default_plugin: true,
         has_default_config: true,
         has_ruby_snippet: false)
       assert_metric_value.call(
-        :stackdriver_enabled_plugins,
+        :enabled_plugins,
         1,
         plugin_name: 'filter/add_insert_ids',
         is_default_plugin: true,
@@ -78,7 +78,7 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
 
       # Default plugins, with custom config.
       assert_metric_value.call(
-        :stackdriver_enabled_plugins,
+        :enabled_plugins,
         1,
         plugin_name: 'match/google_cloud',
         is_default_plugin: true,
@@ -87,21 +87,21 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
 
       # Custom plugins, some with embedded Ruby.
       assert_metric_value.call(
-        :stackdriver_enabled_plugins,
+        :enabled_plugins,
         1,
         plugin_name: 'filter',
         is_default_plugin: false,
         has_default_config: false,
         has_ruby_snippet: false)
       assert_metric_value.call(
-        :stackdriver_enabled_plugins,
+        :enabled_plugins,
         1,
         plugin_name: 'filter/record_transformer',
         is_default_plugin: false,
         has_default_config: false,
         has_ruby_snippet: true)
       assert_metric_value.call(
-        :stackdriver_enabled_plugins,
+        :enabled_plugins,
         1,
         plugin_name: 'match/stdout',
         is_default_plugin: false,
@@ -110,21 +110,21 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
 
       # For out_google_cloud, 3 params are present.
       assert_metric_value.call(
-        :stackdriver_plugin_config,
+        :plugin_config,
         1,
         plugin_name: 'google_cloud',
         param: 'adjust_invalid_timestamps',
         is_present: true,
         has_default_config: true)
       assert_metric_value.call(
-        :stackdriver_plugin_config,
+        :plugin_config,
         1,
         plugin_name: 'google_cloud',
         param: 'autoformat_stackdriver_trace',
         is_present: true,
         has_default_config: false)
       assert_metric_value.call(
-        :stackdriver_plugin_config,
+        :plugin_config,
         1,
         plugin_name: 'google_cloud',
         param: 'coerce_to_utf8',
@@ -163,7 +163,7 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
         zone
       ).each do |p|
         assert_metric_value.call(
-          :stackdriver_plugin_config,
+          :plugin_config,
           1,
           plugin_name: 'google_cloud',
           param: p,
@@ -173,19 +173,19 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
 
       # We also export values for the bools.
       assert_metric_value.call(
-        :stackdriver_config_bool_values,
+        :config_bool_values,
         1,
         plugin_name: 'google_cloud',
         param: 'adjust_invalid_timestamps',
         value: true)
       assert_metric_value.call(
-        :stackdriver_config_bool_values,
+        :config_bool_values,
         1,
         plugin_name: 'google_cloud',
         param: 'autoformat_stackdriver_trace',
         value: false)
       assert_metric_value.call(
-        :stackdriver_config_bool_values,
+        :config_bool_values,
         1,
         plugin_name: 'google_cloud',
         param: 'coerce_to_utf8',


### PR DESCRIPTION
Per discussion offline, we want to send the metrics under `internal/logging/config` instead.

Tested via local Prometheus endpoint in b/153356846. Also tested metrics prefix customization by changing the default prefix temporarily and verify the ingestion of `request_count` metrics.