### PR TITLE
Fix monitoring metrics ingestion via open census.

### DIFF
--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -564,37 +564,37 @@ module Fluent
         # we can't change it.
         @uptime_metric = @registry.counter(
           :uptime, [:version], 'Uptime of Logging agent',
-          'agent.googleapis.com/agent')
+          'agent.googleapis.com/agent', 'CUMULATIVE')
         update_uptime
         timer_execute(:update_uptime, 1) { update_uptime }
         @successful_requests_count = @registry.counter(
           :stackdriver_successful_requests_count,
           [:grpc, :code],
           'A number of successful requests to the Stackdriver Logging API',
-          'agent.googleapis.com/agent')
+          'agent.googleapis.com/agent', 'CUMULATIVE')
         @failed_requests_count = @registry.counter(
           :stackdriver_failed_requests_count,
           [:grpc, :code],
           'A number of failed requests to the Stackdriver Logging '\
           'API, broken down by the error code',
-          'agent.googleapis.com/agent')
+          'agent.googleapis.com/agent', 'CUMULATIVE')
         @ingested_entries_count = @registry.counter(
           :stackdriver_ingested_entries_count,
           [:grpc, :code],
           'A number of log entries ingested by Stackdriver Logging',
-          'agent.googleapis.com/agent')
+          'agent.googleapis.com/agent', 'CUMULATIVE')
         @dropped_entries_count = @registry.counter(
           :stackdriver_dropped_entries_count,
           [:grpc, :code],
           'A number of log entries dropped by the Stackdriver output plugin',
-          'agent.googleapis.com/agent')
+          'agent.googleapis.com/agent', 'CUMULATIVE')
         @retried_entries_count = @registry.counter(
           :stackdriver_retried_entries_count,
           [:grpc, :code],
           'The number of log entries that failed to be ingested by '\
           'the Stackdriver output plugin due to a transient error '\
           'and were retried',
-          'agent.googleapis.com/agent')
+          'agent.googleapis.com/agent', 'CUMULATIVE')
         @ok_code = @use_grpc ? GRPC::Core::StatusCodes::OK : 200
       end
 

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -2025,6 +2025,7 @@ module BaseTest
               if code != ok_status_code
                 0
               elsif config == ENABLE_OPENCENSUS_CONFIG
+                # TODO(b/173215689) Improve the Open Census side of testing.
                 # The test driver instance variables can not survive between
                 # test driver runs. So the open cencensus side counter gets
                 # reset as expected.
@@ -2037,6 +2038,7 @@ module BaseTest
               if code != ok_status_code
                 0
               elsif config == ENABLE_OPENCENSUS_CONFIG
+                # TODO(b/173215689) Improve the Open Census side of testing.
                 # The test driver instance variables can not survive between
                 # test driver runs. So the open cencensus side counter gets
                 # reset as expected.

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -943,22 +943,30 @@ module BaseTest
           d.emit("tag#{i}", 'message' => log_entry(i))
         end
         d.run
+        @logs_sent.zip(request_log_names).each do |request, log_name|
+          assert_equal log_name, request['logName']
+        end
+        verify_log_entries(log_entry_count, COMPUTE_PARAMS_NO_LOG_NAME,
+                           'textPayload') do |entry, entry_index|
+          verify_default_log_entry_text(entry['textPayload'], entry_index,
+                                        entry)
+          assert_equal entry_log_names[entry_index], entry['logName']
+        end
+        # Verify the number of requests is different based on whether the
+        # 'split_logs_by_tag' flag is enabled.
+        assert_prometheus_metric_value(
+          :stackdriver_successful_requests_count,
+          request_count,
+          'agent.googleapis.com/agent',
+          OpenCensus::Stats::Aggregation::Sum, d,
+          :aggregate)
+        assert_prometheus_metric_value(
+          :stackdriver_ingested_entries_count,
+          log_entry_count,
+          'agent.googleapis.com/agent',
+          OpenCensus::Stats::Aggregation::Sum, d,
+          :aggregate)
       end
-      @logs_sent.zip(request_log_names).each do |request, log_name|
-        assert_equal log_name, request['logName']
-      end
-      verify_log_entries(log_entry_count, COMPUTE_PARAMS_NO_LOG_NAME,
-                         'textPayload') do |entry, entry_index|
-        verify_default_log_entry_text(entry['textPayload'], entry_index,
-                                      entry)
-        assert_equal entry_log_names[entry_index], entry['logName']
-      end
-      # Verify the number of requests is different based on whether the
-      # 'split_logs_by_tag' flag is enabled.
-      assert_prometheus_metric_value(:stackdriver_successful_requests_count,
-                                     request_count, :aggregate)
-      assert_prometheus_metric_value(:stackdriver_ingested_entries_count,
-                                     log_entry_count, :aggregate)
     end
   end
 
@@ -1968,7 +1976,9 @@ module BaseTest
         expected = Time.now.to_i - start_time
         d.instance.update_uptime
         assert_metric_value.call(
-          :uptime, expected, version: Fluent::GoogleCloudOutput.version_string)
+          :uptime, expected, 'agent.googleapis.com/agent',
+          OpenCensus::Stats::Aggregation::Sum, d,
+          version: Fluent::GoogleCloudOutput.version_string)
       rescue Test::Unit::AssertionFailedError
         retry if (retries += 1) < 3
       end
@@ -1984,23 +1994,23 @@ module BaseTest
     ].each do |config, assert_metric_value|
       [
         # Single successful request.
-        [ok_status_code, 1, 1, [1, 0, 1, 0, 0]],
+        [ok_status_code, 1, 1, [0, 0, 0]],
         # Several successful requests.
-        [ok_status_code, 2, 1, [2, 0, 2, 0, 0]],
+        [ok_status_code, 2, 1, [0, 0, 0]],
         # Single successful request with several entries.
-        [ok_status_code, 1, 2, [1, 0, 2, 0, 0]],
+        [ok_status_code, 1, 2, [0, 0, 0]],
         # Single failed request that causes logs to be dropped.
-        [client_error_status_code, 1, 1, [0, 1, 0, 1, 0]],
+        [client_error_status_code, 1, 1, [1, 1, 0]],
         # Single failed request that escalates without logs being dropped with
         # several entries.
-        [server_error_status_code, 1, 2, [0, 0, 0, 0, 2]]
+        [server_error_status_code, 1, 2, [0, 0, 2]]
       ].each do |code, request_count, entry_count, metric_values|
         clear_metrics
         setup_logging_stubs(nil, code, 'SomeMessage') do
-          (1..request_count).each do
+          (1..request_count).each do |request_index|
             d = create_driver(config)
-            (1..entry_count).each do |i|
-              d.emit('message' => log_entry(i.to_s))
+            (1..entry_count).each do |entry_index|
+              d.emit('message' => log_entry(entry_index.to_s))
             end
             # rubocop:disable Lint/HandleExceptions
             begin
@@ -2008,30 +2018,64 @@ module BaseTest
             rescue mock_error_type
             end
             # rubocop:enable Lint/HandleExceptions
+            failed_requests_count, dropped_entries_count,
+            retried_entries_count = metric_values
+
+            successful_requests_count = \
+              if code != ok_status_code
+                0
+              elsif config == ENABLE_OPENCENSUS_CONFIG
+                # The test driver instance variables can not survive between
+                # test driver runs. So the open cencensus side counter gets
+                # reset as expected.
+                1
+              else
+                request_index
+              end
+
+            ingested_entries_count = \
+              if code != ok_status_code
+                0
+              elsif config == ENABLE_OPENCENSUS_CONFIG
+                # The test driver instance variables can not survive between
+                # test driver runs. So the open cencensus side counter gets
+                # reset as expected.
+                entry_count
+              else
+                request_index * entry_count
+              end
+
+            assert_metric_value.call(:stackdriver_successful_requests_count,
+                                     successful_requests_count,
+                                     'agent.googleapis.com/agent',
+                                     OpenCensus::Stats::Aggregation::Sum, d,
+                                     grpc: use_grpc, code: ok_status_code)
+            assert_metric_value.call(:stackdriver_ingested_entries_count,
+                                     ingested_entries_count,
+                                     'agent.googleapis.com/agent',
+                                     OpenCensus::Stats::Aggregation::Sum, d,
+                                     grpc: use_grpc, code: ok_status_code)
+            assert_metric_value.call(:stackdriver_retried_entries_count,
+                                     retried_entries_count,
+                                     'agent.googleapis.com/agent',
+                                     OpenCensus::Stats::Aggregation::Sum, d,
+                                     grpc: use_grpc, code: code)
+            # Skip failure assertions when code indicates success, because the
+            # assertion will fail in the case when a single metric contains time
+            # series with success and failure events.
+            next if code == ok_status_code
+            assert_metric_value.call(:stackdriver_failed_requests_count,
+                                     failed_requests_count,
+                                     'agent.googleapis.com/agent',
+                                     OpenCensus::Stats::Aggregation::Sum, d,
+                                     grpc: use_grpc, code: code)
+            assert_metric_value.call(:stackdriver_dropped_entries_count,
+                                     dropped_entries_count,
+                                     'agent.googleapis.com/agent',
+                                     OpenCensus::Stats::Aggregation::Sum, d,
+                                     grpc: use_grpc, code: code)
           end
         end
-        successful_requests_count, failed_requests_count,
-        ingested_entries_count, dropped_entries_count,
-        retried_entries_count = metric_values
-        assert_metric_value.call(:stackdriver_successful_requests_count,
-                                 successful_requests_count,
-                                 grpc: use_grpc, code: ok_status_code)
-        assert_metric_value.call(:stackdriver_ingested_entries_count,
-                                 ingested_entries_count,
-                                 grpc: use_grpc, code: ok_status_code)
-        assert_metric_value.call(:stackdriver_retried_entries_count,
-                                 retried_entries_count,
-                                 grpc: use_grpc, code: code)
-        # Skip failure assertions when code indicates success, because the
-        # assertion will fail in the case when a single metric contains time
-        # series with success and failure events.
-        next if code == ok_status_code
-        assert_metric_value.call(:stackdriver_failed_requests_count,
-                                 failed_requests_count,
-                                 grpc: use_grpc, code: code)
-        assert_metric_value.call(:stackdriver_dropped_entries_count,
-                                 dropped_entries_count,
-                                 grpc: use_grpc, code: code)
       end
     end
   end

--- a/test/plugin/test_filter_analyze_config.rb
+++ b/test/plugin/test_filter_analyze_config.rb
@@ -51,12 +51,15 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
        method(:assert_opencensus_metric_value)]
     ].each do |config, assert_metric_value|
       clear_metrics
-      create_driver(config)
+      d = create_driver(config)
 
       # Default plugins, with default config.
       assert_metric_value.call(
         :enabled_plugins,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'source/syslog/tcp',
         is_default_plugin: true,
         has_default_config: true,
@@ -64,6 +67,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :enabled_plugins,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'source/tail/apache-access',
         is_default_plugin: true,
         has_default_config: true,
@@ -71,6 +77,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :enabled_plugins,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'filter/add_insert_ids',
         is_default_plugin: true,
         has_default_config: true,
@@ -80,6 +89,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :enabled_plugins,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'match/google_cloud',
         is_default_plugin: true,
         has_default_config: false,
@@ -89,6 +101,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :enabled_plugins,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'filter',
         is_default_plugin: false,
         has_default_config: false,
@@ -96,6 +111,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :enabled_plugins,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'filter/record_transformer',
         is_default_plugin: false,
         has_default_config: false,
@@ -103,6 +121,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :enabled_plugins,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'match/stdout',
         is_default_plugin: false,
         has_default_config: false,
@@ -112,6 +133,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :plugin_config,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'google_cloud',
         param: 'adjust_invalid_timestamps',
         is_present: true,
@@ -119,6 +143,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :plugin_config,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'google_cloud',
         param: 'autoformat_stackdriver_trace',
         is_present: true,
@@ -126,6 +153,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :plugin_config,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'google_cloud',
         param: 'coerce_to_utf8',
         is_present: true,
@@ -165,6 +195,9 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
         assert_metric_value.call(
           :plugin_config,
           1,
+          'agent.googleapis.com/agent/internal/logging/config',
+          OpenCensus::Stats::Aggregation::LastValue,
+          d,
           plugin_name: 'google_cloud',
           param: p,
           is_present: false,
@@ -175,18 +208,27 @@ class FilterAnalyzeConfigTest < Test::Unit::TestCase
       assert_metric_value.call(
         :config_bool_values,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'google_cloud',
         param: 'adjust_invalid_timestamps',
         value: true)
       assert_metric_value.call(
         :config_bool_values,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'google_cloud',
         param: 'autoformat_stackdriver_trace',
         value: false)
       assert_metric_value.call(
         :config_bool_values,
         1,
+        'agent.googleapis.com/agent/internal/logging/config',
+        OpenCensus::Stats::Aggregation::LastValue,
+        d,
         plugin_name: 'google_cloud',
         param: 'coerce_to_utf8',
         value: true)

--- a/test/plugin/test_out_google_cloud.rb
+++ b/test/plugin/test_out_google_cloud.rb
@@ -86,13 +86,21 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     end
     d.run
     assert_prometheus_metric_value(
-      :stackdriver_successful_requests_count, 1, grpc: false, code: 200)
+      :stackdriver_successful_requests_count, 1,
+      'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
+      grpc: false, code: 200)
     assert_prometheus_metric_value(
-      :stackdriver_ingested_entries_count, 1, grpc: false, code: 200)
+      :stackdriver_ingested_entries_count, 1,
+      'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
+      grpc: false, code: 200)
     assert_prometheus_metric_value(
-      :stackdriver_dropped_entries_count, 2, grpc: false, code: 3)
+      :stackdriver_dropped_entries_count, 2,
+      'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
+      grpc: false, code: 3)
     assert_prometheus_metric_value(
-      :stackdriver_dropped_entries_count, 1, grpc: false, code: 7)
+      :stackdriver_dropped_entries_count, 1,
+      'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
+      grpc: false, code: 7)
     assert_requested(:post, WRITE_LOG_ENTRIES_URI, times: 1)
   end
 
@@ -109,13 +117,21 @@ class GoogleCloudOutputTest < Test::Unit::TestCase
     d.emit('message' => log_entry(0))
     d.run
     assert_prometheus_metric_value(
-      :stackdriver_successful_requests_count, 0, grpc: false, code: 200)
+      :stackdriver_successful_requests_count, 0,
+      'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
+      grpc: false, code: 200)
     assert_prometheus_metric_value(
-      :stackdriver_failed_requests_count, 1, grpc: false, code: 400)
+      :stackdriver_failed_requests_count, 1,
+      'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
+      grpc: false, code: 400)
     assert_prometheus_metric_value(
-      :stackdriver_ingested_entries_count, 0, grpc: false, code: 200)
+      :stackdriver_ingested_entries_count, 0,
+      'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
+      grpc: false, code: 200)
     assert_prometheus_metric_value(
-      :stackdriver_dropped_entries_count, 1, grpc: false, code: 400)
+      :stackdriver_dropped_entries_count, 1,
+      'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
+      grpc: false, code: 400)
     assert_requested(:post, WRITE_LOG_ENTRIES_URI, times: 1)
   end
 

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -98,18 +98,23 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       d.run
       assert_prometheus_metric_value(
         :stackdriver_successful_requests_count, 1,
+        'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
         grpc: use_grpc, code: GRPC::Core::StatusCodes::OK)
       assert_prometheus_metric_value(
         :stackdriver_failed_requests_count, 0,
+        'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
         grpc: use_grpc, code: GRPC::Core::StatusCodes::PERMISSION_DENIED)
       assert_prometheus_metric_value(
         :stackdriver_ingested_entries_count, 1,
+        'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
         grpc: use_grpc, code: GRPC::Core::StatusCodes::OK)
       assert_prometheus_metric_value(
         :stackdriver_dropped_entries_count, 2,
+        'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
         grpc: use_grpc, code: GRPC::Core::StatusCodes::INVALID_ARGUMENT)
       assert_prometheus_metric_value(
         :stackdriver_dropped_entries_count, 1,
+        'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
         grpc: use_grpc, code: GRPC::Core::StatusCodes::PERMISSION_DENIED)
     end
   end
@@ -127,15 +132,19 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
       d.run
       assert_prometheus_metric_value(
         :stackdriver_successful_requests_count, 0,
+        'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
         grpc: use_grpc, code: GRPC::Core::StatusCodes::OK)
       assert_prometheus_metric_value(
         :stackdriver_failed_requests_count, 1,
+        'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
         grpc: use_grpc, code: GRPC::Core::StatusCodes::INVALID_ARGUMENT)
       assert_prometheus_metric_value(
         :stackdriver_ingested_entries_count, 0,
+        'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
         grpc: use_grpc, code: GRPC::Core::StatusCodes::OK)
       assert_prometheus_metric_value(
         :stackdriver_dropped_entries_count, 1,
+        'agent.googleapis.com/agent', OpenCensus::Stats::Aggregation::Sum, d,
         grpc: use_grpc, code: GRPC::Core::StatusCodes::INVALID_ARGUMENT)
     end
   end


### PR DESCRIPTION
* Add the accidentally removed resource_type back.
* Send the config analysis metrics as GAUGE instead of CUMULATIVE.
* Schedule the config analysis metrics to be exported.