### PR TITLE
Update googleauth version

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -13,7 +13,7 @@ eos
   gem.version       = '0.10.5'
   gem.authors       = ['Stackdriver Agents Team']
   gem.email         = ['stackdriver-agents@google.com']
-  gem.required_ruby_version = Gem::Requirement.new('>= 2.2')
+  gem.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
   gem.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
   gem.test_files    = gem.files.grep(/^(test)/)
@@ -21,8 +21,8 @@ eos
 
   gem.add_runtime_dependency 'fluentd', '1.11.2'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.9'
-  gem.add_runtime_dependency 'googleauth', '0.9.0'
-  gem.add_runtime_dependency 'google-api-client', '0.30.8'
+  gem.add_runtime_dependency 'googleauth', '0.14.0'
+  gem.add_runtime_dependency 'google-api-client', '0.50.0'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
   gem.add_runtime_dependency 'google-protobuf', '3.12.2'
   gem.add_runtime_dependency 'grpc', '1.31.1'

--- a/test/plugin/utils.rb
+++ b/test/plugin/utils.rb
@@ -63,6 +63,7 @@ module Utils
     # Used by 'googleauth' to fetch the default service account credentials.
     stub_request(:get, 'http://169.254.169.254/computeMetadata/v1/' \
                  'instance/service-accounts/default/token')
+      .with(query: hash_including('scopes'))
       .to_return(body: %({"access_token": "#{FAKE_AUTH_TOKEN}"}),
                  status: 200,
                  headers: { 'Content-Length' => FAKE_AUTH_TOKEN.length,


### PR DESCRIPTION
This fixes https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/issues/442 . This also updates `google-api-client` to latest version, and Ruby to version 2.4.0, which are required by latest `googleauth`.

Verified it passes `bundle install`