### PR TITLE
chore: update to fluentd v1.12.3

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -10,7 +10,7 @@ eos
   gem.homepage      =
     'https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud'
   gem.license       = 'Apache-2.0'
-  gem.version       = '0.10.9'
+  gem.version       = '0.11.0'
   gem.authors       = ['Stackdriver Agents Team']
   gem.email         = ['stackdriver-agents@google.com']
   gem.required_ruby_version = Gem::Requirement.new('>= 2.2')
@@ -19,14 +19,14 @@ eos
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'fluentd', '1.11.2'
+  gem.add_runtime_dependency 'fluentd', '1.12.3'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.10'
   gem.add_runtime_dependency 'googleauth', '0.9.0'
   gem.add_runtime_dependency 'google-api-client', '0.30.8'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
   gem.add_runtime_dependency 'google-protobuf', '3.15.8'
   gem.add_runtime_dependency 'grpc', '1.31.1'
-  gem.add_runtime_dependency 'json', '2.2.0'
+  gem.add_runtime_dependency 'json', '2.4.1'
   gem.add_runtime_dependency 'opencensus', '0.5.0'
   gem.add_runtime_dependency 'opencensus-stackdriver', '0.3.2'
 


### PR DESCRIPTION
  - increment gem version for plugin
  - update to allow fluentd v1.12.3 gem
  - update json to 2.4.1 for [CVE-2020-10663](https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/)

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>

Hello maintainers! We are using fluentd-plugin-google-cloud as a plugin in the [kube-fluentd-operator](https://github.com/vmware/kube-fluentd-operator) . We want to be able to migrate to using fluentd v1.12.0 for the benefit of our users, this is the only plugin currently forcing us to use fluentd v1.11.2 . Can we help upgrade? I don't see any breaking changes in the [fluentd changelogs](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md) that will present problems.