### PR TITLE
Relax some Gem dependencies

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -20,11 +20,11 @@ eos
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency 'fluentd', '1.11.2'
-  gem.add_runtime_dependency 'googleapis-common-protos', '1.3.9'
+  gem.add_runtime_dependency 'googleapis-common-protos', '1.3.10'
   gem.add_runtime_dependency 'googleauth', '0.9.0'
   gem.add_runtime_dependency 'google-api-client', '0.30.8'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
-  gem.add_runtime_dependency 'google-protobuf', '3.12.2'
+  gem.add_runtime_dependency 'google-protobuf', '3.14.0'
   gem.add_runtime_dependency 'grpc', '1.31.1'
   gem.add_runtime_dependency 'json', '2.2.0'
   gem.add_runtime_dependency 'opencensus', '0.5.0'


### PR DESCRIPTION
These versions allow this plugin to coexist with other Google Cloud gems, such as google-cloud-pubsub. This enables the following `Gemfile` to work:

```ruby
source 'https://rubygems.org'

gem 'fluent-plugin-google-cloud', '0.10.7'
gem 'google-cloud-pubsub', '2.3.1'
```