### PR TITLE
Fix "calling URI.open via Kernel#open is deprecated" warnings

### DIFF
--- a/lib/fluent/plugin/common.rb
+++ b/lib/fluent/plugin/common.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'open-uri'
+
 module Common
   # Constants for service names, resource types and etc.
   module ServiceConstants
@@ -111,7 +113,7 @@ module Common
       end
 
       begin
-        open('http://' + METADATA_SERVICE_ADDR, proxy: false) do |f|
+        URI.open('http://' + METADATA_SERVICE_ADDR, proxy: false) do |f|
           if f.meta['metadata-flavor'] == 'Google'
             @log.info 'Detected GCE platform'
             return Platform::GCE
@@ -133,9 +135,9 @@ module Common
       raise "Called fetch_gce_metadata with platform=#{platform}" unless
         platform == Platform::GCE
       # See https://cloud.google.com/compute/docs/metadata
-      open('http://' + METADATA_SERVICE_ADDR + '/computeMetadata/v1/' +
-           metadata_path, 'Metadata-Flavor' => 'Google', :proxy => false,
-           &:read)
+      URI.open('http://' + METADATA_SERVICE_ADDR + '/computeMetadata/v1/' +
+               metadata_path, 'Metadata-Flavor' => 'Google', :proxy => false,
+               &:read)
     end
 
     # EC2 Metadata server returns everything in one call. Store it after the
@@ -145,8 +147,9 @@ module Common
         platform == Platform::EC2
       unless @ec2_metadata
         # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-        open('http://' + METADATA_SERVICE_ADDR +
-             '/latest/dynamic/instance-identity/document', proxy: false) do |f|
+        URI.open('http://' + METADATA_SERVICE_ADDR +
+                 '/latest/dynamic/instance-identity/document',
+                 proxy: false) do |f|
           contents = f.read
           @ec2_metadata = JSON.parse(contents)
         end


### PR DESCRIPTION
Closes #431