### PR TITLE
Revert Fluentd from 1.12.3 to 1.11.2 for memory / cpu regression.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -19,6 +19,8 @@ eos
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
 
+  # Note: In order to update the Fluentd version, please update both here and also the fluentd version in
+  # https://github.com/GoogleCloudPlatform/google-fluentd/blob/master/config/software/fluentd.rb.
   gem.add_runtime_dependency 'fluentd', '1.11.2'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.10'
   gem.add_runtime_dependency 'googleauth', '0.9.0'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -19,7 +19,7 @@ eos
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'fluentd', '1.12.3'
+  gem.add_runtime_dependency 'fluentd', '1.11.2'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.10'
   gem.add_runtime_dependency 'googleauth', '0.9.0'
   gem.add_runtime_dependency 'google-api-client', '0.30.8'


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/447#issuecomment-847187748