### PR TITLE
chore(gemspec): update fluentd to 1.13.3

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -27,7 +27,7 @@ eos
   gem.add_runtime_dependency 'googleauth', '0.9.0'
   gem.add_runtime_dependency 'google-api-client', '0.30.8'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
-  gem.add_runtime_dependency 'google-protobuf', '3.15.8'
+  gem.add_runtime_dependency 'google-protobuf', '3.17.3'
   gem.add_runtime_dependency 'grpc', '1.31.1'
   gem.add_runtime_dependency 'json', '2.4.1'
   gem.add_runtime_dependency 'opencensus', '0.5.0'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -29,7 +29,7 @@ eos
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
   gem.add_runtime_dependency 'google-protobuf', '3.15.8'
   gem.add_runtime_dependency 'grpc', '1.31.1'
-  gem.add_runtime_dependency 'json', '2.2.0'
+  gem.add_runtime_dependency 'json', '2.4.1'
   gem.add_runtime_dependency 'opencensus', '0.5.0'
   gem.add_runtime_dependency 'opencensus-stackdriver', '0.3.2'
 


### PR DESCRIPTION
- update to allow fluentd 1.13.3 gem

Fluentd changelog for [v1.13.1](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1131)
Fluentd changelog for [v1.13.2](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1132)
Fluentd changelog for [v1.13.3](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1133)

Signed-off-by: Anton Ouzounov <aouzounov@vmware.com>

