### PR TITLE
Update constant gauge timestamps before exporting.

### DIFF
--- a/lib/fluent/plugin/filter_analyze_config.rb
+++ b/lib/fluent/plugin/filter_analyze_config.rb
@@ -251,10 +251,12 @@ module Fluent
         @registry = Monitoring::MonitoringRegistryFactory.create(
           @monitoring_type, project_id, resource, @gcm_service_address)
         # Export metrics every 60 seconds.
-        timer_execute(:export_config_analysis_metrics, 60) {
-          @registry.update_timestamps(PREFIX) if @registry.respond_to? :update_timestamps
+        timer_execute(:export_config_analysis_metrics, 60) do
+          if @registry.respond_to? :update_timestamps
+            @registry.update_timestamps(PREFIX)
+          end
           @registry.export
-        }
+        end
 
         @log.info('analyze_config plugin: Registering counters.')
         enabled_plugins_counter = @registry.counter(

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -169,11 +169,12 @@ module Monitoring
       new_time = Time.now.utc
       recorder = @recorders[prefix]
       recorder.views_data.each do |view_data|
-        view_data.data.each_value do |aggregation_data|
-          # Apply this only to GAUGE metrics. (This could fail if the metric uses
-          # Distribution or other fancier aggregators.)
-          next unless aggregation_data.is_a? OpenCensus::Stats::AggregationData::LastValue
-          aggregation_data.add aggregation_data.value, new_time
+        view_data.data.each_value do |aggr_data|
+          # Apply this only to GAUGE metrics. This could fail if the metric uses
+          # Distribution or other fancier aggregators.
+          if aggr_data.is_a? OpenCensus::Stats::AggregationData::LastValue
+            aggr_data.add aggr_data.value, new_time
+          end
         end
       end
     end

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -161,6 +161,23 @@ module Monitoring
       raise e
     end
 
+    # Update timestamps for each existing AggregationData without altering tags
+    # or values.
+    # This is currently only used for config analysis metrics, because we want
+    # to repeatedly send the exact same metrics as created at start-up.
+    def update_timestamps(prefix)
+      new_time = Time.now.utc
+      recorder = @recorders[prefix]
+      recorder.views_data.each do |view_data|
+        view_data.data.each_value do |aggregation_data|
+          # Apply this only to GAUGE metrics. (This could fail if the metric uses
+          # Distribution or other fancier aggregators.)
+          next unless aggregation_data.is_a? OpenCensus::Stats::AggregationData::LastValue
+          aggregation_data.add aggregation_data.value, new_time
+        end
+      end
+    end
+
     def export
       @log.debug(
         "monitoring module: Exporting metrics for #{@exporters.keys}.")


### PR DESCRIPTION
http://b/202988791

Updates timestamps for all config analysis metrics before exporting them, without changing any of the measurement tags or values. It creates a "new" data point for each existing time series, by reusing its old value and manually updating the associated time. This is a special case, since we want these to be constant-value gauge metrics, and we don't want to re-parse the user's config every minute.

Before, the exact same config analysis metrics were being sent every minute (same time series, same values, same times), so metrics were only ever ingested for the first export after start-up, and after 24h, it would result in Monitoring API errors and audit logs every minute that looked like:

> Field timeSeries[0].points[0].interval.end_time had an invalid value of "2021-10-20T20:16:34.010866-07:00": Data points cannot be written more than 24h in the past.

Fixing this issue requires:
- this PR
- `opencensus-stackdriver` PR: https://github.com/census-ecosystem/opencensus-ruby-exporter-stackdriver/pull/28
- `opencensus-stackdriver` release with above fix
- update to `opencensus-stackdriver` dependency version [here](https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/fluent-plugin-google-cloud.gemspec#L34) with new version from previous step

Test+verification info documented in http://b/202988791#comment8

Addresses https://github.com/GoogleCloudPlatform/google-fluentd/issues/345
