### PR TITLE
Update opencensus-stackdriver to 0.4.1.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -31,7 +31,7 @@ eos
   gem.add_runtime_dependency 'grpc', '1.31.1'
   gem.add_runtime_dependency 'json', '2.2.0'
   gem.add_runtime_dependency 'opencensus', '0.5.0'
-  gem.add_runtime_dependency 'opencensus-stackdriver', '0.3.2'
+  gem.add_runtime_dependency 'opencensus-stackdriver', '0.4.1'
 
   gem.add_development_dependency 'mocha', '1.9.0'
   # Keep this the same as in


### PR DESCRIPTION
http://b/202988791

This picks up the fix for creating gauge points (https://github.com/census-ecosystem/opencensus-ruby-exporter-stackdriver/pull/28), that (together with https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/477) will enable our config usage metrics to be correctly exported every minute.

When the next Logging Agent is released with this, https://github.com/GoogleCloudPlatform/google-fluentd/issues/345 will be fixed.