### PR TITLE
chore: bump grpc gem to 1.43.1

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -28,7 +28,7 @@ eos
   gem.add_runtime_dependency 'google-api-client', '0.30.8'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
   gem.add_runtime_dependency 'google-protobuf', '3.15.8'
-  gem.add_runtime_dependency 'grpc', '1.31.1'
+  gem.add_runtime_dependency 'grpc', '1.43.1'
   gem.add_runtime_dependency 'json', '2.2.0'
   gem.add_runtime_dependency 'opencensus', '0.5.0'
   gem.add_runtime_dependency 'opencensus-stackdriver', '0.4.1'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -27,7 +27,7 @@ eos
   gem.add_runtime_dependency 'googleauth', '0.9.0'
   gem.add_runtime_dependency 'google-api-client', '0.30.8'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
-  gem.add_runtime_dependency 'google-protobuf', '3.15.8'
+  gem.add_runtime_dependency 'google-protobuf', '3.18.2'
   gem.add_runtime_dependency 'grpc', '1.43.1'
   gem.add_runtime_dependency 'json', '2.2.0'
   gem.add_runtime_dependency 'opencensus', '0.5.0'


### PR DESCRIPTION
Due to a bug in grpc gem you cannot compile this plugin after 10.0 on ARM architecture https://github.com/grpc/grpc/issues/23889

We need to bump this dep up to support native arm extensions