### PR TITLE
Remove Ruby 2.4 and add 2.7 in the testing grid.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ jobs:
       fail-fast: false
       matrix:
         rvm:
+          - 2.7
           - 2.6
           - 2.5
-          - 2.4
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
http://b/219963999
Upgrading grpc from `1.31.1` → `1.43.1` requires Ruby >= `2.5.0`

![image](https://user-images.githubusercontent.com/35477443/158714861-0c681dd9-fe27-40ed-921f-279b92d88c90.png)
