### PR TITLE
 Call URI.open directly 

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -10,7 +10,7 @@ eos
   gem.homepage      =
     'https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud'
   gem.license       = 'Apache-2.0'
-  gem.version       = '0.12.9'
+  gem.version       = '0.12.10'
   gem.authors       = ['Stackdriver Agents Team']
   gem.email         = ['stackdriver-agents@google.com']
   gem.required_ruby_version = Gem::Requirement.new('>= 2.2')

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -10,7 +10,7 @@ eos
   gem.homepage      =
     'https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud'
   gem.license       = 'Apache-2.0'
-  gem.version       = '0.12.10'
+  gem.version       = '0.12.9'
   gem.authors       = ['Stackdriver Agents Team']
   gem.email         = ['stackdriver-agents@google.com']
   gem.required_ruby_version = Gem::Requirement.new('>= 2.2')

--- a/lib/fluent/plugin/common.rb
+++ b/lib/fluent/plugin/common.rb
@@ -132,10 +132,10 @@ module Common
     def fetch_gce_metadata(platform, metadata_path)
       raise "Called fetch_gce_metadata with platform=#{platform}" unless
         platform == Platform::GCE
-        # See https://cloud.google.com/compute/docs/metadata
-        URI.open('http://' + METADATA_SERVICE_ADDR + '/computeMetadata/v1/' +
-                 metadata_path, 'Metadata-Flavor' => 'Google', :proxy => false,
-                 &:read)
+      # See https://cloud.google.com/compute/docs/metadata
+      URI.open('http://' + METADATA_SERVICE_ADDR + '/computeMetadata/v1/' +
+               metadata_path, 'Metadata-Flavor' => 'Google', :proxy => false,
+               &:read)
     end
 
     # EC2 Metadata server returns everything in one call. Store it after the

--- a/lib/fluent/plugin/common.rb
+++ b/lib/fluent/plugin/common.rb
@@ -111,7 +111,7 @@ module Common
       end
 
       begin
-        open('http://' + METADATA_SERVICE_ADDR, proxy: false) do |f|
+        URI.open('http://' + METADATA_SERVICE_ADDR, proxy: false) do |f|
           if f.meta['metadata-flavor'] == 'Google'
             @log.info 'Detected GCE platform'
             return Platform::GCE
@@ -133,7 +133,7 @@ module Common
       raise "Called fetch_gce_metadata with platform=#{platform}" unless
         platform == Platform::GCE
       # See https://cloud.google.com/compute/docs/metadata
-      open('http://' + METADATA_SERVICE_ADDR + '/computeMetadata/v1/' +
+        URI.open('http://' + METADATA_SERVICE_ADDR + '/computeMetadata/v1/' +
            metadata_path, 'Metadata-Flavor' => 'Google', :proxy => false,
            &:read)
     end
@@ -145,7 +145,7 @@ module Common
         platform == Platform::EC2
       unless @ec2_metadata
         # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-        open('http://' + METADATA_SERVICE_ADDR +
+        URI.open('http://' + METADATA_SERVICE_ADDR +
              '/latest/dynamic/instance-identity/document', proxy: false) do |f|
           contents = f.read
           @ec2_metadata = JSON.parse(contents)

--- a/lib/fluent/plugin/common.rb
+++ b/lib/fluent/plugin/common.rb
@@ -132,10 +132,10 @@ module Common
     def fetch_gce_metadata(platform, metadata_path)
       raise "Called fetch_gce_metadata with platform=#{platform}" unless
         platform == Platform::GCE
-      # See https://cloud.google.com/compute/docs/metadata
+        # See https://cloud.google.com/compute/docs/metadata
         URI.open('http://' + METADATA_SERVICE_ADDR + '/computeMetadata/v1/' +
-           metadata_path, 'Metadata-Flavor' => 'Google', :proxy => false,
-           &:read)
+                 metadata_path, 'Metadata-Flavor' => 'Google', :proxy => false,
+                 &:read)
     end
 
     # EC2 Metadata server returns everything in one call. Store it after the


### PR DESCRIPTION
This shall hopefully remediate the error we saw from google-fluentd:

![image](https://user-images.githubusercontent.com/8354694/199338456-fe4751b5-dbeb-496a-bf2a-f4c3bbe6cb05.png)

