### PR TITLE
Upgrade json to 2.3.0

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -29,7 +29,7 @@ eos
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
   gem.add_runtime_dependency 'google-protobuf', '3.20.0'
   gem.add_runtime_dependency 'grpc', '1.45.0'
-  gem.add_runtime_dependency 'json', '2.2.0'
+  gem.add_runtime_dependency 'json', '2.3.0'
   gem.add_runtime_dependency 'opencensus', '0.5.0'
   gem.add_runtime_dependency 'opencensus-stackdriver', '0.4.1'
 


### PR DESCRIPTION
I would like to update the `json` gem to resolve the following vulnerability.

- [CVE-2020-10663](https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/)

Due to [the performance concern](https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/466
), I chose to update to 2.3.0 which resolves the vulnerability with the least impact on this product.

If you prefer to update to the latest version ([2.6.2](https://rubygems.org/gems/json/versions/2.2.0?locale=ja)), I can create a pull request.