### PR TITLE
Update google-api-client to 0.53.0

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -25,7 +25,7 @@ eos
   gem.add_runtime_dependency 'fluentd', '1.13.3'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.10'
   gem.add_runtime_dependency 'googleauth', '0.9.0'
-  gem.add_runtime_dependency 'google-api-client', '0.30.8'
+  gem.add_runtime_dependency 'google-api-client', '0.53.0'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'
   gem.add_runtime_dependency 'google-protobuf', '3.20.0'
   gem.add_runtime_dependency 'grpc', '1.45.0'


### PR DESCRIPTION
Update google-api-client to allow the plugin to be installed on ruby 3.x

Fixes #472