### PR TITLE
Bump google-api-client to be compatible with Ruby 3.

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   # also the fluentd version in
   # https://github.com/GoogleCloudPlatform/google-fluentd/blob/master/config/software/fluentd.rb.
   gem.add_runtime_dependency 'fluentd', '1.13.3'
-  gem.add_runtime_dependency 'google-api-client', '0.30.8'
+  gem.add_runtime_dependency 'google-api-client', '0.44.2'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.3.10'
   gem.add_runtime_dependency 'googleauth', '0.9.0'
   gem.add_runtime_dependency 'google-cloud-logging', '1.6.6'


### PR DESCRIPTION
This is to allow building the logging agent with Ruby 3 later, avoiding errors like this (caused by https://github.com/rubygems/rubygems/issues/4338):
```
ERROR:  While executing gem ... (NoMethodError)
    undefined method `request' for nil:NilClass

    [@failed_dep.dependency, @activated.request.dependency]
                                       ^^^^^^^^
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver/conflict.rb:47](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver/conflict.rb?l=47&cl=514852906):in `conflicting_dependencies'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/exceptions.rb:61](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/exceptions.rb?l=61&cl=514852906):in `conflicting_dependencies'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/exceptions.rb:55](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/exceptions.rb?l=55&cl=514852906):in `initialize'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver.rb:193](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver.rb?l=193&cl=514852906):in `exception'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver.rb:193](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver.rb?l=193&cl=514852906):in `raise'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver.rb:193](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver.rb?l=193&cl=514852906):in `rescue in resolve'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver.rb:191](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/resolver.rb?l=191&cl=514852906):in `resolve'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/request_set.rb:411](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/request_set.rb?l=411&cl=514852906):in `resolve'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/dependency_installer.rb:333](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/dependency_installer.rb?l=333&cl=514852906):in `resolve_dependencies'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb:201](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb?l=201&cl=514852906):in `install_gem'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb:226](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb?l=226&cl=514852906):in `block in install_gems'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb:219](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb?l=219&cl=514852906):in `each'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb:219](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb?l=219&cl=514852906):in `install_gems'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb:167](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/commands/install_command.rb?l=167&cl=514852906):in `execute'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/command.rb:323](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/command.rb?l=323&cl=514852906):in `invoke_with_build_args'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/command_manager.rb:185](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/command_manager.rb?l=185&cl=514852906):in `process_args'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/command_manager.rb:149](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/command_manager.rb?l=149&cl=514852906):in `run'
	/[usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/gem_runner.rb:51](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/gem_runner.rb?l=51&cl=514852906):in `run'
	/[usr/local/rvm/rubies/ruby-3.1.3/bin/gem:21](https://cs.corp.google.com/piper///depot/google3/usr/local/rvm/rubies/ruby-3.1.3/bin/gem?l=21&cl=514852906):in `<main>'
```

[b/254273286](http://b/254273286)