### PR TITLE
gemspec: update fluentd version to v1.16.2

### DIFF
--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   # NOTE: In order to update the Fluentd version, please update both here and
   # also the fluentd version in
   # https://github.com/GoogleCloudPlatform/google-fluentd/blob/master/config/software/fluentd.rb.
-  gem.add_runtime_dependency 'fluentd', '1.13.3'
+  gem.add_runtime_dependency 'fluentd', '1.16.2'
   gem.add_runtime_dependency 'google-api-client', '0.53.0'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.4.0'
   gem.add_runtime_dependency 'googleauth', '1.3.0'


### PR DESCRIPTION
Tracker: (b/293350172](b/293350172)

There have been several memory leak fixes since v1.13.3. Updating the version and having this run using our soak tests will help us see if we see some improvements. 

Related PR: https://github.com/GoogleCloudPlatform/google-fluentd/pull/422