### PR TITLE
Upgrade gRPC to 1.65.2, Ruby to 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ jobs:
       matrix:
         rvm:
           - 2.7
-          - 2.6
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     # Generated files.
     - 'lib/google/**/*'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.version       = '0.13.2'
   gem.authors       = ['Stackdriver Agents Team']
   gem.email         = ['stackdriver-agents@google.com']
-  gem.required_ruby_version = Gem::Requirement.new('>= 2.6')
+  gem.required_ruby_version = Gem::Requirement.new('>= 2.7')
 
   gem.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
   gem.test_files    = gem.files.grep(/^(test)/)
@@ -28,8 +28,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'googleauth', '1.3.0'
   gem.add_runtime_dependency 'google-cloud-logging', '2.3.2'
   gem.add_runtime_dependency 'google-cloud-monitoring-v3', '0.10.0'
-  gem.add_runtime_dependency 'google-protobuf', '3.22.1'
-  gem.add_runtime_dependency 'grpc', '1.53.0'
+  gem.add_runtime_dependency 'google-protobuf', '3.25.5'
+  gem.add_runtime_dependency 'grpc', '1.65.2'
   gem.add_runtime_dependency 'json', '2.6.3'
   gem.add_runtime_dependency 'opencensus', '0.5.0'
   gem.add_runtime_dependency 'opencensus-stackdriver', '0.4.1'


### PR DESCRIPTION
Need a newer version of gRPC for compatibility with Ruby 3.3.5.

gRPC requires Ruby 3.x starting with version 1.66.0, so pick the newest version before 1.66.0.

That version requires Ruby 2.7, so upgrade to that as well.