### PR TITLE
Upgrade fluentd to 1.19, Ruby to 3.2,grpc to 1.70.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         rvm:
-          - 2.7
+          - 3.2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   Exclude:
     # Generated files.
     - 'lib/google/**/*'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -10,10 +10,10 @@ Gem::Specification.new do |gem|
   gem.homepage      =
     'https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud'
   gem.license       = 'Apache-2.0'
-  gem.version       = '0.13.4'
+  gem.version       = '0.13.5'
   gem.authors       = ['Stackdriver Agents Team']
   gem.email         = ['stackdriver-agents@google.com']
-  gem.required_ruby_version = Gem::Requirement.new('>= 2.7')
+  gem.required_ruby_version = Gem::Requirement.new('>= 3.2')
 
   gem.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
   gem.test_files    = gem.files.grep(/^(test)/)
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   # NOTE: In order to update the Fluentd version, please update both here and
   # also the fluentd version in
   # https://github.com/GoogleCloudPlatform/google-fluentd/blob/master/config/software/fluentd.rb.
-  gem.add_runtime_dependency 'fluentd', '1.16.2'
+  gem.add_runtime_dependency 'fluentd', '1.19.0'
   gem.add_runtime_dependency 'google-api-client', '0.53.0'
   gem.add_runtime_dependency 'googleapis-common-protos', '1.4.0'
   gem.add_runtime_dependency 'googleauth', '1.3.0'

--- a/fluent-plugin-google-cloud.gemspec
+++ b/fluent-plugin-google-cloud.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'google-cloud-logging', '2.3.2'
   gem.add_runtime_dependency 'google-cloud-monitoring-v3', '0.10.0'
   gem.add_runtime_dependency 'google-protobuf', '3.25.5'
-  gem.add_runtime_dependency 'grpc', '1.65.2'
+  gem.add_runtime_dependency 'grpc', '1.70.1'
   gem.add_runtime_dependency 'json', '2.6.3'
   gem.add_runtime_dependency 'opencensus', '0.5.0'
   gem.add_runtime_dependency 'opencensus-stackdriver', '0.4.1'

--- a/lib/fluent/plugin/common.rb
+++ b/lib/fluent/plugin/common.rb
@@ -226,7 +226,7 @@ module Common
     # Create a monitored resource from type and labels.
     def create_monitored_resource(type, labels)
       Google::Apis::LoggingV2::MonitoredResource.new(
-        type: type, labels: labels.to_h
+        type:, labels: labels.to_h
       )
     end
 

--- a/lib/fluent/plugin/filter_analyze_config.rb
+++ b/lib/fluent/plugin/filter_analyze_config.rb
@@ -19,7 +19,6 @@ require 'fluent/plugin_helper'
 require 'googleauth'
 require 'google/apis/logging_v2'
 require 'open-uri'
-require 'set'
 
 require_relative 'common'
 require_relative 'monitoring'
@@ -336,9 +335,9 @@ module Fluent
           end
           enabled_plugins_counter.increment(
             labels: {
-              plugin_name: plugin_name,
-              is_default_plugin: is_default_plugin,
-              has_default_config: has_default_config,
+              plugin_name:,
+              is_default_plugin:,
+              has_default_config:,
               has_ruby_snippet: embedded_ruby?(e)
             },
             by: 1

--- a/lib/fluent/plugin/monitoring.rb
+++ b/lib/fluent/plugin/monitoring.rb
@@ -155,7 +155,7 @@ module Monitoring
       @recorders[prefix].register_view(
         OpenCensus::Stats::View.new(
           name: translator.name,
-          measure: measure,
+          measure:,
           aggregation: stats_aggregation,
           description: docstring,
           columns: translator.view_labels.map(&:to_s)

--- a/lib/fluent/plugin/out_google_cloud.rb
+++ b/lib/fluent/plugin/out_google_cloud.rb
@@ -775,8 +775,8 @@ module Fluent
         )}"
 
         requests_to_send << {
-          entries: entries,
-          log_name: log_name,
+          entries:,
+          log_name:,
           resource: group_level_resource,
           labels: group_level_common_labels
         }
@@ -847,7 +847,7 @@ module Fluent
                                            ts_secs,
                                            ts_nanos)
       entry = Google::Cloud::Logging::V2::LogEntry.new(
-        labels: labels,
+        labels:,
         resource: Google::Api::MonitoredResource.new(
           type: resource.type,
           labels: resource.labels.to_h
@@ -876,9 +876,9 @@ module Fluent
       # Remove the labels if we didn't populate them with anything.
       resource.labels = nil if resource.labels.empty?
       Google::Apis::LoggingV2::LogEntry.new(
-        labels: labels,
-        resource: resource,
-        severity: severity,
+        labels:,
+        resource:,
+        severity:,
         timestamp: {
           seconds: ts_secs,
           nanos: ts_nanos
@@ -893,8 +893,8 @@ module Fluent
       client = api_client
       entries_count = entries.length
       client.write_log_entries(
-        entries: entries,
-        log_name: log_name,
+        entries:,
+        log_name:,
         # Leave resource nil if it's nil.
         resource: if resource
                     Google::Api::MonitoredResource.new(
@@ -1026,10 +1026,10 @@ module Fluent
       entries_count = entries.length
       client.write_entry_log_entries(
         Google::Apis::LoggingV2::WriteLogEntriesRequest.new(
-          entries: entries,
-          log_name: log_name,
-          resource: resource,
-          labels: labels,
+          entries:,
+          log_name:,
+          resource:,
+          labels:,
           partial_success: true
         ),
         options: { api_format_version: '2' }
@@ -1657,13 +1657,13 @@ module Fluent
       nanos = (match['decimal'].to_f * 1000 * 1000 * 1000).round
       if @use_grpc
         Google::Protobuf::Duration.new(
-          seconds: seconds,
-          nanos: nanos
+          seconds:,
+          nanos:
         )
       else
         {
-          seconds: seconds,
-          nanos: nanos
+          seconds:,
+          nanos:
         }.delete_if { |_, v| v.zero? }
       end
     end
@@ -2125,7 +2125,7 @@ module Fluent
       end
       constructed_resource = Google::Apis::LoggingV2::MonitoredResource.new(
         type: resource_type,
-        labels: labels
+        labels:
       )
       @log.debug("Constructed #{resource_type} resource locally: " \
                  "#{constructed_resource.inspect}")
@@ -2157,7 +2157,7 @@ module Fluent
       return unless @failed_requests_count
 
       @failed_requests_count.increment(
-        labels: { grpc: @use_grpc, code: code }
+        labels: { grpc: @use_grpc, code: }
       )
     end
 
@@ -2177,7 +2177,7 @@ module Fluent
       return unless @dropped_entries_count
 
       @dropped_entries_count.increment(
-        labels: { grpc: @use_grpc, code: code }, by: count
+        labels: { grpc: @use_grpc, code: }, by: count
       )
     end
 
@@ -2187,7 +2187,7 @@ module Fluent
       return unless @retried_entries_count
 
       @retried_entries_count.increment(
-        labels: { grpc: @use_grpc, code: code }, by: count
+        labels: { grpc: @use_grpc, code: }, by: count
       )
     end
   end

--- a/lib/fluent/plugin/statusz.rb
+++ b/lib/fluent/plugin/statusz.rb
@@ -26,8 +26,8 @@ module Statusz
                         minutes: (uptime / 60) % 60,
                         seconds: uptime % 60)
     ERB.new(STATUSZ_TMPL).result_with_hash(
-      plugin: plugin,
-      uptime_str: uptime_str
+      plugin:,
+      uptime_str:
     )
   end
 end

--- a/test/plugin/base_test.rb
+++ b/test/plugin/base_test.rb
@@ -2110,7 +2110,7 @@ module BaseTest
                                      retried_entries_count,
                                      'agent.googleapis.com/agent',
                                      OpenCensus::Stats::Aggregation::Sum, d,
-                                     grpc: use_grpc, code: code)
+                                     grpc: use_grpc, code:)
             # Skip failure assertions when code indicates success, because the
             # assertion will fail in the case when a single metric contains time
             # series with success and failure events.
@@ -2120,12 +2120,12 @@ module BaseTest
                                      failed_requests_count,
                                      'agent.googleapis.com/agent',
                                      OpenCensus::Stats::Aggregation::Sum, d,
-                                     grpc: use_grpc, code: code)
+                                     grpc: use_grpc, code:)
             assert_metric_value.call(:stackdriver_dropped_entries_count,
                                      dropped_entries_count,
                                      'agent.googleapis.com/agent',
                                      OpenCensus::Stats::Aggregation::Sum, d,
-                                     grpc: use_grpc, code: code)
+                                     grpc: use_grpc, code:)
           end
         end
       end
@@ -2152,7 +2152,7 @@ module BaseTest
     log, container_name = K8S_CONTAINER_NAME
   )
     {
-      log: log,
+      log:,
       stream: K8S_STREAM,
       time: K8S_TIMESTAMP,
       kubernetes: {
@@ -2160,7 +2160,7 @@ module BaseTest
         namespace_name: K8S_NAMESPACE_NAME,
         pod_id: CONTAINER_POD_ID,
         pod_name: K8S_POD_NAME,
-        container_name: container_name,
+        container_name:,
         labels: {
           CONTAINER_LABEL_KEY => CONTAINER_LABEL_VALUE
         }
@@ -2170,8 +2170,8 @@ module BaseTest
 
   def container_log_entry(log, stream = K8S_STREAM)
     {
-      log: log,
-      stream: stream,
+      log:,
+      stream:,
       time: K8S_TIMESTAMP
     }
   end
@@ -2179,7 +2179,7 @@ module BaseTest
   def k8s_container_log_entry(log,
                               local_resource_id: K8S_LOCAL_RESOURCE_ID)
     {
-      log: log,
+      log:,
       stream: K8S_STREAM,
       time: K8S_TIMESTAMP,
       LOCAL_RESOURCE_ID_KEY => local_resource_id
@@ -2188,7 +2188,7 @@ module BaseTest
 
   def k8s_pod_log_entry(log)
     {
-      log: log,
+      log:,
       stream: K8S_STREAM,
       time: K8S_TIMESTAMP,
       LOCAL_RESOURCE_ID_KEY =>
@@ -2200,7 +2200,7 @@ module BaseTest
 
   def k8s_node_log_entry(log)
     {
-      log: log,
+      log:,
       stream: K8S_STREAM,
       time: K8S_TIMESTAMP,
       LOCAL_RESOURCE_ID_KEY =>
@@ -2219,7 +2219,7 @@ module BaseTest
   def dataproc_log_entry(message, source_class = 'com.example.Example',
                          filename = 'test.log')
     {
-      filename: filename,
+      filename:,
       class: source_class,
       message: log_entry(message)
     }

--- a/test/plugin/test_out_google_cloud_grpc.rb
+++ b/test/plugin/test_out_google_cloud_grpc.rb
@@ -346,11 +346,11 @@ class GoogleCloudOutputGRPCTest < Test::Unit::TestCase
                           labels: nil,
                           partial_success: nil)
       request = Google::Apis::LoggingV2::WriteLogEntriesRequest.new(
-        log_name: log_name,
-        resource: resource,
-        labels: labels,
-        entries: entries,
-        partial_success: partial_success
+        log_name:,
+        resource:,
+        labels:,
+        entries:,
+        partial_success:
       )
       @requests_received << request
       WriteLogEntriesResponse.new


### PR DESCRIPTION
Summary: Upgrade fluentd to 1.19, Ruby to 3.2, grpc to 1.70.1

Fix linting issues pointed by robocop.

Fixes #519 

Test plan
```
bundle install

bundle exec rake


➜  fluent-plugin-google-cloud git:(upgrade_fluentd) ✗ bundle exec rake

Running RuboCop...
Inspecting 20 files
....................

20 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-rake (https://rubygems.org/gems/rubocop-rake)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
/home/ubuntu/.rvm/rubies/ruby-3.2.2/bin/ruby -w -I"lib:lib:test" /home/ubuntu/.rvm/rubies/ruby-3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/plugin/asserts.rb" "test/plugin/base_test.rb" "test/plugin/constants.rb" "test/plugin/test_driver.rb" "test/plugin/test_filter_add_insert_ids.rb" "test/plugin/test_filter_analyze_config.rb" "test/plugin/test_out_google_cloud.rb" "test/plugin/test_out_google_cloud_grpc.rb" "test/plugin/utils.rb"
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
/home/ubuntu/.rvm/gems/ruby-3.2.2/gems/io-event-1.10.2/lib/io/event/support.rb:48: warning: IO::Buffer is experimental and both the Ruby and C interface may change in the future!
/home/ubuntu/.rvm/gems/ruby-3.2.2/gems/fluentd-1.19.0/lib/fluent/plugin_helper.rb:46: warning: method redefined; discarding old inherited
/home/ubuntu/.rvm/gems/ruby-3.2.2/gems/fluentd-1.19.0/lib/fluent/plugin_helper.rb:46: warning: previous definition of inherited was here
/home/ubuntu/.rvm/gems/ruby-3.2.2/gems/google-apis-core-0.11.3/lib/google/apis/core/base_service.rb:228: warning: method redefined; discarding old client
/home/ubuntu/.rvm/gems/ruby-3.2.2/gems/google-cloud-logging-v2-0.11.0/lib/google/logging/v2/logging_pb.rb:25: warning: assigned but unused variable - e
/home/ubuntu/.rvm/gems/ruby-3.2.2/gems/google-cloud-logging-v2-0.11.0/lib/google/logging/v2/log_entry_pb.rb:24: warning: assigned but unused variable - e
/home/ubuntu/.rvm/gems/ruby-3.2.2/gems/google-cloud-logging-v2-0.11.0/lib/google/logging/v2/logging_config_pb.rb:24: warning: assigned but unused variable - e
/home/ubuntu/.rvm/gems/ruby-3.2.2/gems/google-cloud-logging-v2-0.11.0/lib/google/logging/v2/logging_metrics_pb.rb:24: warning: assigned but unused variable - e
Loaded suite /home/ubuntu/.rvm/rubies/ruby-3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
.../home/ubuntu/.rvm/gems/ruby-3.2.2/gems/google-cloud-trace-v2-0.7.0/lib/google/devtools/cloudtrace/v2/tracing_pb.rb:22: warning: assigned but unused variable - e
/home/ubuntu/.rvm/gems/ruby-3.2.2/gems/google-cloud-trace-v2-0.7.0/lib/google/devtools/cloudtrace/v2/trace_pb.rb:21: warning: assigned but unused variable - e
.............................................................................................................................................................................................................................................
Finished in 324.598372469 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
240 tests, 36418 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.74 tests/s, 112.19 assertions/s
[Coveralls] Outside the CI environment, not sending data.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR

```

Build gem
```
rake build
```